### PR TITLE
Nginx changes to reflect change in Gelato endpoint/api version.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,7 +45,7 @@ cat > /etc/nginx/conf.d/default.conf <<EOF
         }
 
         location /${OPENSDS_GELATO_API_VERSION}/ {
-            proxy_pass ${OPENSDS_GELATO_URL}/${OPENSDS_GELATO_API_VERSION}/;
+            proxy_pass ${OPENSDS_GELATO_URL}/;
             client_max_body_size 10240m;
         }
     }


### PR DESCRIPTION
The API path for the multi-cloud Gelato has been changed from v1/. 
This PR fixes that and updates the nginx configuration to reflect that change.