### PR TITLE
Fixed #357 and #358. Fixed broken date display in cloud volume and timeout issue.

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -701,7 +701,6 @@ export class AppComponent implements OnInit, AfterViewInit {
             step => {
                 let scrollElm = document.scrollingElement;
                 scrollElm.scrollTop = 0;
-                console.log('Next:', step);
             },
             e => {
                 console.log('Error', e);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -440,6 +440,7 @@ export class AppComponent implements OnInit, AfterViewInit {
                 options['headers'] = new Headers();
                 options = this.BucketService.getSignatureOptions(requestOptions, options);
                 this.http.put(uploadUrl + '?partNumber=' + (i + 1) + '&uploadId=' + uploadId, chunk, options).subscribe((data) => {
+                    this.refreshLastTime();
                     let header = data.headers['_headers']
                     let headerArr = header.entries()
                     let headerArr1= Array.from(headerArr)
@@ -1005,6 +1006,8 @@ export class AppComponent implements OnInit, AfterViewInit {
             this.username = "";
             this.password = "";
             this.isLogin = false;
+            this.showPrompt = false;
+            window['isUpload'] = false;
         }, 500);
 
     }

--- a/src/app/business/block/bucket-detail/bucket-detail.component.ts
+++ b/src/app/business/block/bucket-detail/bucket-detail.component.ts
@@ -256,7 +256,7 @@ export class BucketDetailComponent implements OnInit {
           let backupAllDir = JSON.parse( JSON.stringify( this.allDir ) );
           this.resolveObject();
           //Data in folder
-          if(this.folderId !=""){
+          if(this.folderId && this.folderId !=""){
             if(!this.folderId.endsWith(this.colon)){
               this.folderId = this.folderId + this.colon;
             }

--- a/src/app/business/block/cloud-block-service/cloud-block-service.component.html
+++ b/src/app/business/block/cloud-block-service/cloud-block-service.component.html
@@ -50,7 +50,7 @@
                             {{label.createdAt}}:
                         </div>
                         <div class="ui-grid-col-3 volume-basic-item-value-color">
-                            {{volume.createdAt ? (volume.createdAt | date:'long') : '--'}}
+                            {{volume.createdAt ? volume.createdAt : '--'}}
                         </div>
                         
                     </div>

--- a/src/app/business/block/cloud-block-service/cloud-block-service.component.html
+++ b/src/app/business/block/cloud-block-service/cloud-block-service.component.html
@@ -25,7 +25,7 @@
         </p-column>
         <p-column field="createdAt" header="Created At">
             <ng-template pTemplate="body" let-volume="rowData">
-                <span>{{volume.createdAt ? (volume.createdAt | date:'long') : '--'}}</span>
+                <span>{{volume.createdAt ? volume.createdAt  : '--'}}</span>
             </ng-template>
         </p-column>
         <p-column header="{{I18N.keyID['sds_block_volume_operation']}}" [style]="{'width': '200px'}">

--- a/src/app/business/block/cloud-block-service/cloud-block-service.component.ts
+++ b/src/app/business/block/cloud-block-service/cloud-block-service.component.ts
@@ -151,14 +151,16 @@ export class CloudBlockServiceComponent implements OnInit{
 
 
             });
-            this.cloudBS.getVolumesByBackend(this.backendId).subscribe((res) => {
-                let vols = res.json() && res.json().volumes ? res.json().volumes : [];
-                this.allAWSVolumes = vols;
-                
-            }, (error) => {
-                this.allAWSVolumes = [];
-                console.log("Something went wrong. Error fetching file shares", error);
-            })
+            if(this.backendId){
+                this.cloudBS.getVolumesByBackend(this.backendId).subscribe((res) => {
+                    let vols = res.json() && res.json().volumes ? res.json().volumes : [];
+                    this.allAWSVolumes = vols;
+                    
+                }, (error) => {
+                    this.allAWSVolumes = [];
+                    console.log("Something went wrong. Error fetching file shares", error);
+                })
+            }
         });
     }
 

--- a/src/app/business/block/volumeList.html
+++ b/src/app/business/block/volumeList.html
@@ -31,8 +31,8 @@
             <p-column field="availabilityZone" header="{{I18N.keyID['sds_block_volume_az']}}" [style]="{'width': '15%'}"></p-column>
             <p-column header="{{I18N.keyID['sds_block_volume_operation']}}" [style]="{'width': '350px'}">
                 <ng-template pTemplate="body" let-volume="rowData" let-i="rowIndex">
-                    <a (click)="returnSelectedVolume(volume,'snapshot')">{{I18N.keyID['sds_block_volume_createsna']}}</a>
-                    <a [ngClass]="{'a-rep-disabled':volume['isDisableRep']}" (click)="returnSelectedVolume(volume,'replication')">{{I18N.keyID['sds_block_volume_createrep']}}</a>
+                    <a [ngClass]="{'a-rep-disabled':volume['status']=='error'?true:false}" (click)="returnSelectedVolume(volume,'snapshot')">{{I18N.keyID['sds_block_volume_createsna']}}</a>
+                    <a [ngClass]="{'a-rep-disabled':volume['isDisableRep'] || (volume['status']=='error'?true:false)}" (click)="returnSelectedVolume(volume,'replication')">{{I18N.keyID['sds_block_volume_createrep']}}</a>
                     <p-dropmenu label="{{I18N.keyID['sds_block_volume_more']}}" [model]="volume['disabled'] ? menuDeleDisableItems: menuItems" (click)="returnSelectedVolume(volume)"></p-dropmenu>
                 </ng-template>
             </p-column>


### PR DESCRIPTION
**What type of PR is this?**
/kind bug fix

**What this PR does / why we need it**:
- This PR fixes the issue of UI breaking when the cloud volume page in Firefox and Edge browser.
There was a date pipe added on the `createdAt` field to display a human readable date. The API response was already a human readable date and not a date string. 
Fixed it by removing the date pipe added.

- This PR also fixes the API call made to get all cloud volumes when there are no backends created.
- Also fixes null getting appended to the object title in a bucket on a fresh install when no objects have been uploaded to the system yet.


 - This PR also fixes the timeout error while uploading a large file. If the user does not use the browser during that time then the browser tab logs out and the upload gets canceled. 

**Which issue(s) this PR fixes**:
Fixes #357  and #358 

**Test Report Added?**:
/kind TESTED


**Test Report**:

**Special notes for your reviewer**:
