### PR TITLE
[Fixes #373] Fixed envsubst not working on Ubuntu18.04/CentOS8 on VirtualBox

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,7 +66,7 @@ cat /etc/nginx/conf.d/default.conf
 echo "Starting application..."
 echo "OPENSDS_S3_HOST = ${OPENSDS_S3_HOST}"
 echo "OPENSDS_S3_PORT = ${OPENSDS_S3_PORT}"
-envsubst '\${OPENSDS_S3_HOST} \${OPENSDS_S3_PORT}' < "/var/www/html/assets/data/runtime.json" > "/var/www/html/assets/data/runtime.json"
+echo "{\"hostIP\": \"$OPENSDS_S3_HOST\",\"hostPort\": \"$OPENSDS_S3_PORT\"}" >/var/www/html/assets/data/runtime.json
 
 # start nginx service
 /usr/sbin/nginx -g "daemon off;"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug fix

**What this PR does / why we need it**:
This PR fixes the issue of dashboard not accessible on fresh installation on Ubuntu18.04 and CentOS8 on VirtualBox.
During the process of bringing up the docker container for dashboard the `entrypoint.sh` file is executed. As part of the initialisation the nginx configuration and environment variable substitution is performed.
This environment variable substitution  is performed using the following line: [link here](https://github.com/sodafoundation/dashboard/blob/981c68f33f4ea3b4296a81e35ad84cf8335515b2/entrypoint.sh#L69)
`envsubst '\${OPENSDS_S3_HOST} \${OPENSDS_S3_PORT}' < "/var/www/html/assets/data/runtime.json" > "/var/www/html/assets/data/runtime.json"`

This code works on Ubuntu 16.04 and Ubuntu 18.04 when installing on a VM or a Laptop. But while installing on VirtualBox using Ubuntu18.04 or CentOS8 the above line does not execute. 
The envsubst command is shipped with the `nginx:alpine` image on which the docker container for the dashboard is based and is the recommended way to replace environment variables at runtime.

To solve this issue the line is replaced with the following line:
`echo "{\"hostIP\": \"$OPENSDS_S3_HOST\",\"hostPort\": \"$OPENSDS_S3_PORT\"}" >/var/www/html/assets/data/runtime.json`

**Which issue(s) this PR fixes**:

Fixes #373 

**Test Report Added?**:
/kind TESTED


**Test Report**:

**Special notes for your reviewer**:
Tested on VirtualBox installation of Ubuntu18.04. Able to access the dashboard.