### PR TITLE
Added Storage array Details. Added Volumes & pool component. Storage capacity and Alerts Tab

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -37,6 +37,7 @@ const routes: Routes = [
     {path: 'fileShareDetail/:fileShareId', loadChildren: './business/block/file-share-detail/file-share-detail.module#FileShareDetailModule'},
     {path: 'services', loadChildren: './business/services/services.module#ServicesModule'},
     {path: 'delfin', loadChildren: './business/delfin/delfin.module#DelfinModule'}
+    {path: 'storageDetails/:storageId', loadChildren: './business/delfin/storage-details/storage-details.module#StorageDetailsModule'},
 ];
 
 @NgModule({

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -36,7 +36,7 @@ const routes: Routes = [
     {path: 'modifyCloudFileShare/:fileShareId', loadChildren: './business/block/cloud-file-share/modify/cloud-file-share-modify.module#CloudFileShareModifyModule'},
     {path: 'fileShareDetail/:fileShareId', loadChildren: './business/block/file-share-detail/file-share-detail.module#FileShareDetailModule'},
     {path: 'services', loadChildren: './business/services/services.module#ServicesModule'},
-    {path: 'delfin', loadChildren: './business/delfin/delfin.module#DelfinModule'}
+    {path: 'delfin', loadChildren: './business/delfin/delfin.module#DelfinModule'},
     {path: 'storageDetails/:storageId', loadChildren: './business/delfin/storage-details/storage-details.module#StorageDetailsModule'},
 ];
 

--- a/src/app/business/delfin/delfin.module.ts
+++ b/src/app/business/delfin/delfin.module.ts
@@ -6,6 +6,7 @@ import { ScrollPanelModule } from '../../components/scrollpanel/scrollpanel';
 import { DataScrollerModule } from '../../components/datascroller/datascroller';
 import { TreeModule } from '../../components/tree/tree';
 import { ProgressBarModule } from '../../components/progressbar/progressbar';
+import { ContextMenuModule } from '../../components/contextmenu/contextmenu';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { HttpService } from './../../shared/service/Http.service';
 import { DelfinComponent } from './delfin.component';
@@ -56,7 +57,8 @@ const routers: Routes = [{
     ConfirmDialogModule,
     InputTextareaModule,
     TooltipModule,
-    ProgressBarModule
+    ProgressBarModule,
+    ContextMenuModule
     ],
   exports: [ DelfinComponent ],
   providers: [

--- a/src/app/business/delfin/delfin.module.ts
+++ b/src/app/business/delfin/delfin.module.ts
@@ -16,7 +16,8 @@ import { TooltipModule } from '../../components/tooltip/tooltip';
 import { StoragesComponent } from './storages/storages.component';
 import { TableModule } from '../../components/table/table';
 import { DataViewModule } from '../../components/dataview/dataview';
-
+import { StorageVolumesComponent } from './volumes/volumes.component';
+import { StoragePoolsComponent } from './storage-pools/storage-pools.component';
 import { FieldsetModule } from '../../components/fieldset/fieldset'
 
 const routers: Routes = [{

--- a/src/app/business/delfin/delfin.service.ts
+++ b/src/app/business/delfin/delfin.service.ts
@@ -52,8 +52,34 @@ export class DelfinService {
     }
 
     //get all Volumes
-    getAllVolumes(): Observable<any> {
-        return this.http.get(this.delfinVolumesUrl);
+    getAllVolumes(storageId?, nativeVolumeId?, nativeStoragePoolId?, name?, status?, limit?, offset?, sort?): Observable<any> {
+        let query = "";
+        if(storageId){
+            query += "?storage_id=" + storageId;
+        }
+        if(nativeVolumeId){
+            query += "?native_volume_id=" + nativeVolumeId;
+        }
+        if(nativeStoragePoolId){
+            query += "?native_storage_pool_id=" + nativeStoragePoolId;
+        }
+        if(name){
+            query += "?name=" + name;
+        }
+        if(status){
+            query += "?status=" + status;
+        }
+        if(limit){
+            query += "?limit=" + limit;
+        }
+        if(offset){
+            query += "?offset=" + offset;
+        }
+        if(sort){
+            query += "?sort=" + sort;
+        }
+        let url =this.delfinVolumesUrl + query;
+        return this.http.get(url);
     }
 
     //get Volume Details
@@ -62,8 +88,34 @@ export class DelfinService {
     }
 
     //get all Storage pools
-    getAllStoragePools(): Observable<any> {
-        return this.http.get(this.delfinStoragePoolsUrl);
+    getAllStoragePools(storageId?, storagePoolId?, nativeStoragePoolId?, name?, status?, limit?, offset?, sort?): Observable<any> {
+        let query = "";
+        if(storageId){
+            query += "?storage_id=" + storageId;
+        }
+        if(storagePoolId){
+            query += "?id=" + storagePoolId;
+        }
+        if(nativeStoragePoolId){
+            query += "?native_storage_pool_id=" + nativeStoragePoolId;
+        }
+        if(name){
+            query += "?name=" + name;
+        }
+        if(status){
+            query += "?status=" + status;
+        }
+        if(limit){
+            query += "?limit=" + limit;
+        }
+        if(offset){
+            query += "?offset=" + offset;
+        }
+        if(sort){
+            query += "?sort=" + sort;
+        }
+        let url =this.delfinStoragePoolsUrl + query;
+        return this.http.get(url);
     }
 
     //get Storage Pool details
@@ -84,6 +136,16 @@ export class DelfinService {
     //delete alert source
     deleteAlertSource(id): Observable<any>{
         return this.http.delete(this.delfinStoragesUrl + '/' + id + '/alert-source')
+    }
+
+    //Get All alerts
+    getAllAlerts(): Observable<any>{
+        return this.http.get(this.delfinStoragesUrl + '/alerts');
+    }
+
+    //Get Alerts by Storage ID
+    getAlertsByStorageId(storageId): Observable<any>{
+        return this.http.get(this.delfinStoragesUrl + '/' + storageId + '/alerts/');
     }
 
     //delete alerts

--- a/src/app/business/delfin/storage-details/storage-details.component.html
+++ b/src/app/business/delfin/storage-details/storage-details.component.html
@@ -1,0 +1,279 @@
+<p-growl [value]="msgs" [sticky]="false" [life]="6000"></p-growl>
+<div>
+    <div class="custom-breadcrumb">
+        <span *ngFor="let item of items; index as i">
+          <a [ngClass]="{'font-color-class': i===0}" [routerLink]="[item.url]">{{item.label}}</a>
+          <span *ngIf="(i+1) !== items.length">></span>
+        </span>
+    </div>
+    <div class="table-toolbar">
+        <div class="left">
+            
+        </div>
+        <div class="right">
+            <button pButton type="button" (click)="syncStorage(selectedStorageId)" icon="fa-exchange" label="Sync Storage"></button>
+            <button class="" title="Refresh" label="Refresh" pButton type="button" (click)="getStorageById(selectedStorageId)" icon="fa-refresh"></button>
+        </div>
+    </div>
+    <div>
+        <p-tabView styleClass="ui-tabview-large" (onChange)="changeDetailsTab($event)" [activeIndex]="detailsTabIndex">
+            <p-tabPanel header="Configuration">
+                    <div class="details-basic-info">
+                        <div class="ui-grid ui-grid-responsive ui-grid-pad ui-fluid">
+                            <div class="ui-grid-col-12">
+                                <div class="ui-grid-row details-basic-item-class">
+                                    <div class="ui-grid-col-2">
+                                        {{label.name}}:
+                                    </div>
+                                    <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="selectedStorage">
+                                        {{selectedStorage.name}}
+                                    </div>
+                                    <div class="ui-grid-col-2">
+                                        {{label.status}}:
+                                    </div>
+                                    <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="selectedStorage">
+                                        <span class="storage-status-icon" [ngClass]="{normal: selectedStorage.status=='normal', abnormal: selectedStorage.status=='abnormal' || selectedStorage.status=='offline'}"><i class="fa fa-circle"></i></span>
+                                        <span *ngIf="selectedStorage.status=='normal'">Normal</span>
+                                        <span *ngIf="selectedStorage.status=='abnormal'">Abnormal</span>
+                                        <span *ngIf="selectedStorage.status=='offline'">Offline</span>
+                                    </div>
+                                    <div class="ui-grid-col-2">
+                                        {{label.sync_status}}
+                                    </div>
+                                    <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="selectedStorage">
+                                        <span>{{selectedStorage.sync_status ? selectedStorage.sync_status : '--'}}</span>
+                                        <span *ngIf="selectedStorage.sync_status=='SYNCING'" ><i class="fa fa-spinner fa-pulse"></i></span>
+                                    </div>
+                                
+                                </div>
+                                <div class="ui-grid-row details-basic-item-class">
+                                    <div class="ui-grid-col-2">
+                                        {{label.id}}:
+                                    </div>
+                                    <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="selectedStorage">
+                                        {{selectedStorage.id | slice:0:20}}
+                                        <a *ngIf="selectedStorage.id.length > 20" pTooltip="{{selectedStorage.id}}" tooltipPosition="top">
+                                            ...
+                                        </a>
+                                    </div>
+                                    <div class="ui-grid-col-2">
+                                        {{label.firmware_version}}:
+                                    </div>
+                                    <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="selectedStorage">
+                                        {{selectedStorage.firmware_version}}
+                                    </div>
+                                    <div class="ui-grid-col-2">
+                                        {{label.created_at}}:
+                                    </div>
+                                    <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="selectedStorage">
+                                        {{selectedStorage.created_at ? (selectedStorage.created_at | date:'long') : '--'}}
+                                    </div>
+                                    
+                                </div>
+                                <div class="ui-grid-row details-basic-item-class">
+                                        <div class="ui-grid-col-2">
+                                            {{label.vendor}} / {{label.model}}:
+                                        </div>
+                                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="selectedStorage">
+                                            {{selectedStorage.vendor}} / {{selectedStorage.model}}
+                                        </div>
+                                        <div class="ui-grid-col-2">
+                                            {{label.serial_number}}:
+                                        </div>
+                                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="selectedStorage">
+                                            {{ selectedStorage.serial_number | slice:0:20 }}
+                                            <a *ngIf="selectedStorage.serial_number.length > 20" pTooltip="{{selectedStorage.serial_number}}" tooltipPosition="top">
+                                                ...
+                                            </a>
+                                        </div>
+                                        
+                                        <div class="ui-grid-col-2">
+                                            {{label.updated_at}}:
+                                        </div>
+                                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="selectedStorage">
+                                            {{selectedStorage.updated_at ? (selectedStorage.updated_at | date:'long') : '--'}}
+                                        </div>
+                                </div>
+                                <div class="ui-grid-row details-basic-item-class">
+                                    <div class="ui-grid-col-2">
+                                        {{label.description}}:
+                                    </div>
+                                    <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="selectedStorage">
+                                        {{ selectedStorage.description | slice:0:20 }}
+                                        <a *ngIf="selectedStorage.description.length > 20" pTooltip="{{selectedStorage.description}}" tooltipPosition="top">
+                                            ...
+                                        </a>
+                                    </div>
+                                    <div class="ui-grid-col-2">
+                                        {{label.location}}:
+                                    </div>
+                                    <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="selectedStorage">
+                                        {{selectedStorage.location ? selectedStorage.location : '--'}}
+                                    </div>
+                                    <div class="ui-grid-col-2">
+                                    </div>
+                                    <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="selectedStorage">
+                                    </div>
+                                </div>
+                                <div class="ui-grid-row details-basic-item-class">
+                                    <div class="ui-grid-col-12">
+                                        <span>Capacity Summary</span>
+                                    </div>
+                                </div>
+                                <div class="ui-grid-row details-basic-item-class">
+                                    <div class="ui-grid-col-2">
+                                        {{label.raw_capacity}}:
+                                    </div>
+                                    <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="selectedStorage">
+                                        {{ selectedStorage.capacity.raw}}
+                                    </div>
+                                    <div class="ui-grid-col-2">
+                                        {{label.subscribed_capacity}}:
+                                    </div>
+                                    <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="selectedStorage">
+                                        {{ selectedStorage.capacity.subscribed}}
+                                    </div>
+                                    <div class="ui-grid-col-2">
+                                        {{label.system_used}}:
+                                    </div>
+                                    <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="selectedStorage">
+                                        {{ selectedStorage.capacity.system_used}}
+                                    </div>
+                                </div>
+                                <div class="ui-grid-row details-basic-item-class">
+                                    <div class="ui-grid-col-2">
+                                        {{label.free_capacity}}:
+                                    </div>
+                                    <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="selectedStorage">
+                                        {{ selectedStorage.capacity.free}}
+                                    </div>
+                                    <div class="ui-grid-col-2">
+                                        {{label.used_capacity}}:
+                                    </div>
+                                    <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="selectedStorage">
+                                        {{ selectedStorage.capacity.used}}
+                                    </div>
+                                    <div class="ui-grid-col-2">
+                                        {{label.total_capacity}}:
+                                    </div>
+                                    <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="selectedStorage">
+                                        {{ selectedStorage.capacity.total}}
+                                    </div>
+                                </div>
+                                
+                            </div>
+                        </div>
+                    </div>
+                <div class="configuration-tabs">
+                    <p-tabView styleClass="ui-tabview-large" (onChange)="changeConfigTab($event)" [activeIndex]="configTabIndex"> 
+                        <p-tabPanel header="Volumes">
+                            <ng-template pTemplate="content">
+                                <app-delfin-volumes [selectedStorage]="selectedStorageId"></app-delfin-volumes>
+                            </ng-template>
+                        </p-tabPanel>
+                        <p-tabPanel header="Storage pools">
+                            <app-delfin-storage-pools [selectedStorage]="selectedStorageId"></app-delfin-storage-pools>
+                        </p-tabPanel>
+                        
+                    </p-tabView>
+                </div>
+            </p-tabPanel>
+            <p-tabPanel header="Capacity">
+                <ng-template pTemplate="content">
+                    <div class="ui-grid-row">
+                        <div class="ui-g-6">
+                            <p-card styleClass="ui-card-shadow">
+                                <p-header style="padding: 0.15rem 0.2rem 0 0.2rem;">
+                                    <div class="ui-g-row summary-card-header-container" >
+                                        <div class="ui-g-6 left-items" style="padding-left: 0.2rem;">
+                                            <div class="ui-card-title">Array Usable Capacity</div>
+                                            <div class="ui-card-subtitle">Total Usable Capacity: {{selectedStorage && selectedStorage.capacity.total}}</div>
+                                        </div>
+                                        <div class="ui-g-offset-4 ui-g-2">
+                                            
+                                        </div>
+                                    </div>
+                                </p-header>
+                                <div>
+                                    <p-chart type="doughnut" [data]="usableCapacityChartData" [options]="usableCapacityChartOptions" [responsive]="true"></p-chart>        
+                                </div>
+                                <p-footer>
+                                </p-footer>
+                            </p-card>
+                            
+                        </div>
+                        <div class="ui-g-6">
+                            <p-card styleClass="ui-card-shadow">
+                                <p-header style="padding: 0.15rem 0.2rem 0 0.2rem;">
+                                    <div class="ui-g-row summary-card-header-container" >
+                                        <div class="ui-g-6 left-items" style="padding-left: 0.2rem;">
+                                            <div class="ui-card-title">Array Raw Capacity</div>
+                                            <div class="ui-card-subtitle">Total Raw Capacity: {{selectedStorage && selectedStorage.capacity.raw}}</div>
+                                        </div>
+                                        <div class="ui-g-offset-4 ui-g-2">
+                                            
+                                        </div>
+                                    </div>
+                                </p-header>
+                                <div>
+                                    <p-chart type="doughnut" [data]="rawCapacityChartData" [options]="rawCapacityChartOptions" [responsive]="true"></p-chart>
+                                </div>
+                                <p-footer>
+                                </p-footer>
+                            </p-card>
+                            
+                        </div>
+                    </div>
+                    <div class="ui-grid-row">
+                        <div class="ui-g-4">
+                            
+                        </div>
+                        <div class="ui-g-8">
+                            
+                        </div>
+                    </div>
+                </ng-template>
+            </p-tabPanel>
+            <p-tabPanel header="Alerts">
+                <ng-template pTemplate="content">
+                    <div class="ui-grid-row">
+                        <div class="table-toolbar">
+                            <div class="left">
+
+                            </div>
+                            <div class="right">
+                                <div class="ui-inputsearch">
+                                    <input type="text" #searchAll pInputText placeholder="{{i18n.keyID['sds_block_volume_search']}}">
+                                    <button pButton type="button" icon="fa-search"></button>
+                                </div>
+                                
+                                <button class="" title="Refresh list" pButton type="button" (click)="getAllActiveAlerts(selectedStorageId)" icon="fa-refresh"></button>
+                            </div>
+                        </div>
+                        <p-dataTable [value]="allActiveAlerts" [resizableColumns]="true" [rows]="10" [paginator]="true" [pageLinks]="3" [rowsPerPageOptions]="[5,10,15]">
+                            <p-column field="alert_name" header="Alert Name" [sortable]="true" [style]="{'width': '20%'}">
+                                <ng-template pTemplate="body" let-alert="rowData">
+                                    <a title="{{alert.alert_name}}">{{alert.alert_name}}</a>
+                                </ng-template>
+                            </p-column>
+                            <p-column field="description" header="Description" [sortable]="true" [style]="{'width': '40%'}"></p-column>
+                            <p-column header="Trigerring Object" [sortable]="true" [style]="{'width': '20%'}">
+                                <ng-template pTemplate="body" let-alert="rowData" >
+                                    <a title="{{alert.storage_name}}">{{alert.storage_name}} / {{alert.serial_number}}</a>
+                                </ng-template>
+                            </p-column>
+                            <p-column field="severity" header="Severity" [style]="{'width': '20%'}">
+                                <ng-template pTemplate="body" let-alert="rowData" >
+                                    <span>{{alert.severity}}</span>
+                                </ng-template>
+                            </p-column>
+                        </p-dataTable>
+                    </div>
+                </ng-template>
+            </p-tabPanel>
+        </p-tabView>
+    </div>
+    
+    
+</div>
+

--- a/src/app/business/delfin/storage-details/storage-details.component.html
+++ b/src/app/business/delfin/storage-details/storage-details.component.html
@@ -181,6 +181,59 @@
             <p-tabPanel header="Capacity">
                 <ng-template pTemplate="content">
                     <div class="ui-grid-row">
+                        <div class="ui-g-4 capacity-overview-container total">
+                            <div class="ui-g-6 capacity-overview-label-tile">
+                                {{label.total_capacity}}:
+                            </div>
+                            <div class="ui-g-6 capacity-overview-value-tile">
+                                {{ selectedStorage.capacity.total}}
+                            </div>
+                        </div>
+                        <div class="ui-g-4 capacity-overview-container free">
+                            <div class="ui-g-6 capacity-overview-label-tile">
+                                {{label.free_capacity}}:
+                            </div>
+                            <div class="ui-g-6 capacity-overview-value-tile">
+                                {{ selectedStorage.capacity.free}}
+                            </div>
+                        </div>
+                        <div class="ui-g-4 capacity-overview-container used">
+                            <div class="ui-g-6 capacity-overview-label-tile">
+                                {{label.used_capacity}}:
+                            </div>
+                            <div class="ui-g-6 capacity-overview-value-tile">
+                                {{ selectedStorage.capacity.used}}
+                            </div>
+                        </div>
+                    </div>
+                    <div class="ui-grid-row">
+                        <div class="ui-g-4 capacity-overview-container raw">
+                            <div class="ui-g-6 capacity-overview-label-tile">
+                                {{label.raw_capacity}}:
+                            </div>
+                            <div class="ui-g-6 capacity-overview-value-tile">
+                                {{ selectedStorage.capacity.raw}}
+                            </div>
+                        </div>
+                        <div class="ui-g-4 capacity-overview-container system-used">
+                            <div class="ui-g-6 capacity-overview-label-tile">
+                                {{label.system_used}}:
+                            </div>
+                            <div class="ui-g-6 capacity-overview-value-tile">
+                                {{ selectedStorage.capacity.system_used}}
+                            </div>
+                        </div>
+                        <div class="ui-g-4 capacity-overview-container subscribed">
+                            <div class="ui-g-6 capacity-overview-label-tile">
+                                {{label.subscribed_capacity}}:
+                            </div>
+                            <div class="ui-g-6 capacity-overview-value-tile">
+                                {{ selectedStorage.capacity.subscribed}}
+                            </div>
+                        </div>
+                    </div>
+                   
+                    <div class="ui-grid-row">
                         <div class="ui-g-6">
                             <p-card styleClass="ui-card-shadow">
                                 <p-header style="padding: 0.15rem 0.2rem 0 0.2rem;">
@@ -225,11 +278,48 @@
                         </div>
                     </div>
                     <div class="ui-grid-row">
-                        <div class="ui-g-4">
-                            
+                        <div class="ui-g-6">
+                            <p-card styleClass="ui-card-shadow">
+                                <p-header style="padding: 0.15rem 0.2rem 0 0.2rem;">
+                                    <div class="ui-g-row summary-card-header-container" >
+                                        <div class="ui-g-10 left-items" style="padding-left: 0.2rem;">
+                                            <div class="ui-card-title">Volumes Overview</div>
+                                            <div class="ui-card-subtitle">
+                                                <span>Total Number of Volumes: {{allVolumesCountAndCapacity.total }}</span> <br /> 
+                                                <span>Total Volumes Capacity: {{allVolumesCountAndCapacity && allVolumesCountAndCapacity.displayTotal}}</span>
+                                            </div>
+                                        </div>
+                                        
+                                    </div>
+                                </p-header>
+                                <div>
+                                    <p-chart type="doughnut" [data]="volumesCapacityChartData" [options]="volumesCapacityChartOptions" [responsive]="true"></p-chart>
+                                </div>
+                                
+                                <p-footer>
+                                </p-footer>
+                            </p-card>
                         </div>
-                        <div class="ui-g-8">
-                            
+                        <div class="ui-g-6">
+                            <p-card styleClass="ui-card-shadow">
+                                <p-header style="padding: 0.15rem 0.2rem 0 0.2rem;">
+                                    <div class="ui-g-row summary-card-header-container" >
+                                        <div class="ui-g-10 left-items" style="padding-left: 0.2rem;">
+                                            <div class="ui-card-title">Storage Pools Overview</div>
+                                            <div class="ui-card-subtitle">
+                                                <span>Total Number of Pools: {{allPoolsCountAndCapacity.total }}</span> <br />
+                                                <span>Total Storage Pools Capacity: {{allPoolsCountAndCapacity && allPoolsCountAndCapacity.displayTotal}}</span>
+                                            </div>
+                                        </div>
+                                        
+                                    </div>
+                                </p-header>
+                                <div>
+                                    <p-chart type="doughnut" [data]="poolsCapacityChartData" [options]="poolsCapacityChartOptions" [responsive]="true"></p-chart>
+                                </div>
+                                <p-footer>
+                                </p-footer>
+                            </p-card>
                         </div>
                     </div>
                 </ng-template>

--- a/src/app/business/delfin/storage-details/storage-details.component.ts
+++ b/src/app/business/delfin/storage-details/storage-details.component.ts
@@ -1,0 +1,385 @@
+import { Component, OnInit, ViewContainerRef, ViewChild, Directive, ElementRef, HostBinding, HostListener } from '@angular/core';
+import { Router, ActivatedRoute } from '@angular/router';
+import { I18NService, Utils } from 'app/shared/api';
+import { FormControl, FormGroup, FormBuilder, Validators, ValidatorFn, AbstractControl } from '@angular/forms';
+import { AppService } from 'app/app.service';
+import { I18nPluralPipe } from '@angular/common';
+import { trigger, state, style, transition, animate } from '@angular/animations';
+import { Message, MenuItem ,ConfirmationService} from '../../../components/common/api';
+import { DelfinService } from '../delfin.service';
+
+
+let _ = require("underscore");
+@Component({
+    selector: 'app-delfin-storage-details',
+    templateUrl: 'storage-details.component.html',
+    providers: [ConfirmationService],
+    styleUrls: [],
+    animations: []
+})
+export class StorageDetailsComponent implements OnInit {
+    allStorages: any = [];
+    selectedStorage: any;
+    selectedStorageId: any;
+    items: any;
+    usableCapacityChartData: any;
+    usableCapacityChartOptions: any;
+    rawCapacityChartData: any;
+    rawCapacityChartOptions: any;
+    allActiveAlerts: any = [];
+    detailsTabIndex: number = 0;
+    configTabIndex: number = 0;
+    msgs: Message[];
+
+    label = {
+        name: this.i18n.keyID["sds_block_volume_name"],
+        description: this.i18n.keyID["sds_block_volume_descri"],
+        vendor: "Vendor",
+        model: "Model",
+        status: "Status",
+        host: "Host IP",
+        port: "Port",
+        extra_attributes: "Extra Attributes",
+        created_at: "Registered At",
+        updated_at: "Updated At",
+        firmware_version: "Firmware Version",
+        serial_number : "Serial Number",
+        location : "Location",
+        free_capacity: "Free Capacity",
+        used_capacity: "Used Capacity",
+        total_capacity: "Total Capacity",
+        raw_capacity: "Raw capacity",
+        subscribed_capacity: "Subscribed Capacity",
+        system_used: "System Used",
+        id: "Delfin ID",
+        sync_status : "Sync Status"
+
+    };
+
+    constructor(
+        private ActivatedRoute: ActivatedRoute,
+        public i18n: I18NService,
+        private confirmationService: ConfirmationService,
+        private fb: FormBuilder,
+        private ds: DelfinService
+    ) {
+        this.ActivatedRoute.params.subscribe((params) => {
+            this.selectedStorageId = params.storageId;
+        });
+        
+    }
+
+    ngOnInit() {
+        this.getStorageById(this.selectedStorageId);
+        
+        this.items = [
+            { 
+                label: "Storages", 
+                url: '/delfin' 
+            },
+            { 
+                label: "Storage Details", 
+                url: '/storageDetails' 
+            }
+        ];
+        
+        
+    }
+    changeDetailsTab(e){
+        let index = e.index;
+        switch (index) {
+            case 0:
+                this.detailsTabIndex = 0;
+                this.configTabIndex = 0;
+                this.getStorageById(this.selectedStorageId);
+                break;
+            case 1:
+                this.detailsTabIndex = 1;
+                this.getStorageById(this.selectedStorageId);
+                this.prepareCapacityCharts(this.selectedStorage);
+                break;
+            case 2:
+                this.detailsTabIndex = 2;
+                this.getAllActiveAlerts(this.selectedStorageId);
+                break;
+            default:
+                break;
+        }
+    }
+
+    changeConfigTab(e){
+        let index = e.index;
+        switch (index) {
+            case 0:
+                this.configTabIndex = 0;
+                break;
+            case 1:
+                this.configTabIndex = 1;
+                break;
+            default:
+                break;
+        }
+    }
+
+    getAllStorages(){
+        this.ds.getAllStorages().subscribe((res)=>{
+            let storages = res.json().storages;
+            this.allStorages = storages;
+        }, (error)=>{
+            console.log("Something went wrong. Could not fetch all storages", error);
+        })
+    }
+
+    getStorageById(id){
+        this.ds.getStorageById(id).subscribe((res)=>{
+            let storageDevice;
+            storageDevice = res.json();
+            storageDevice['capacity'] = {};
+            let percentUsage = Math.ceil((storageDevice['used_capacity']/storageDevice['total_capacity']) * 100);
+            storageDevice['capacity'].used = Utils.formatBytes(storageDevice['used_capacity']);
+            storageDevice['capacity'].free = Utils.formatBytes(storageDevice['free_capacity']);
+            storageDevice['capacity'].total = Utils.formatBytes(storageDevice['total_capacity']);
+            storageDevice['capacity'].raw = Utils.formatBytes(storageDevice['raw_capacity']);
+            storageDevice['capacity'].subscribed = Utils.formatBytes(storageDevice['subscribed_capacity']);
+            let system_used = Math.ceil((storageDevice['raw_capacity'] - storageDevice['total_capacity']));
+            storageDevice['system_used_capacity'] = system_used;
+            storageDevice['capacity'].system_used = Utils.formatBytes(storageDevice['system_used_capacity']) ;
+            storageDevice['capacity'].usage = percentUsage;
+
+            this.selectedStorage = storageDevice;
+        }, (error)=>{
+            console.log("Something went wrong. Could not fetch storage", error);
+        })
+    }
+
+    prepareCapacityCharts(storage){
+        this.usableCapacityChartData = {
+            labels: ['Used: ' + storage['capacity'].used,'Free: ' + storage['capacity'].free],
+            datasets: [
+                {
+                    data: [storage['used_capacity'], storage['free_capacity']],
+                    backgroundColor: [
+                        'rgba(255, 99, 132, 0.2)',
+                        'rgba(54, 162, 235, 0.2)',
+                      ],
+                      borderColor: [
+                        'rgba(255,99,132,1)',
+                        'rgba(54, 162, 235, 1)',
+                      ],
+                    borderWidth: 1,
+                    hoverBackgroundColor: [
+                        'rgba(255, 99, 132, 1)',
+                        'rgba(54, 162, 235, 1)'
+                    ]
+                }]    
+        };
+        this.usableCapacityChartOptions = {
+            legend: {
+                display: true,
+                position: 'right',
+                labels: {
+                    fontColor: 'rgb(0,0,0)',
+                    fontSize: 14
+                }
+            },
+            tooltips: {
+              callbacks: {
+                title: function(tooltipItem, data) {
+                  return data['labels'][tooltipItem[0]['index']];
+                },
+                label: function(tooltipItem, data) {
+                },
+                afterLabel: function(tooltipItem, data) {
+                }
+              },
+              backgroundColor: '#ccc',
+              titleFontSize: 14,
+              titleFontColor: '#0066ff',
+              bodyFontColor: '#000',
+              bodyFontSize: 14,
+              displayColors: false
+            }
+        };
+
+        this.rawCapacityChartData = {
+            labels: ['Total Capacity: ' + storage['capacity'].total,'System Used: ' + storage['capacity'].system_used],
+            datasets: [
+                {
+                    data: [storage['total_capacity'], storage['system_used_capacity']],
+                    backgroundColor: [
+                        'rgba(0, 109, 226, 0.5)',
+                        'rgba(68, 68, 68, 0.5)'
+                    ],
+                    borderColor : [
+                        'rgba(0, 109, 226,1)',
+                        'rgba(68, 68, 68, 1)'
+                    ],
+                    borderWidth: 1,
+                    hoverBackgroundColor: [
+                        'rgba(0, 109, 226, 1)',
+                        'rgba(68, 68, 68, 1)'
+                    ]
+                }]    
+        };
+        this.rawCapacityChartOptions = {
+            legend: {
+                display: true,
+                position: 'right',
+                labels: {
+                    fontColor: 'rgb(0,0,0)',
+                    fontSize: 14
+                }
+            },
+            tooltips: {
+              callbacks: {
+                title: function(tooltipItem, data) {
+                  return data['labels'][tooltipItem[0]['index']];
+                },
+                label: function(tooltipItem, data) {
+                  
+                },
+                afterLabel: function(tooltipItem, data) {
+                   
+                }
+              },
+              backgroundColor: '#ccc',
+              titleFontSize: 14,
+              titleFontColor: '#0066ff',
+              bodyFontColor: '#000',
+              bodyFontSize: 14,
+              displayColors: false
+            }
+          };
+    }
+
+    syncStorage(storageId){
+        this.ds.syncStorageById(storageId).subscribe((res)=>{
+            this.msgs = [];
+            this.msgs.push({severity: 'success', summary: 'Success', detail: 'Sync request has been sent. Please check back in some time.'});
+            this.getAllStorages();
+        }, (error)=>{
+            this.msgs = [];
+            let errorMsg = 'Error Syncing device.' + error.error_msg;
+            this.msgs.push({severity: 'error', summary: 'Error', detail: error});
+            console.log("Something went wrong. Could not initiate the sync.", error);
+        });
+    }
+
+    getAllActiveAlerts(storageId){
+        this.ds.getAlertsByStorageId(storageId).subscribe((res)=>{
+            this.allActiveAlerts = res.json().alerts;
+        }, (error)=>{
+            this.allActiveAlerts = [];
+            console.log("Something went wrong. Could not fetch alerts.", error);
+            this.msgs = [];
+            let errorMsg = 'Error fetching alerts.' + error.error_msg;
+            this.msgs.push({severity: 'error', summary: 'Error', detail: error});
+        })
+        // FIXME ALERTS DUMMY DATA
+        /* this.allActiveAlerts.push(
+            {
+                'alert_id' : '255911',
+                'alert_name' : 'TP VV allocation failure',
+                'severity' : 'Critical',
+                'category' : 'Fault',
+                'type' : 'EquipmentAlarm',
+                'sequence_number' : 657,
+                'occur_time' : 1514140673000,
+                'description' : 'Thin provisioned VV LUN_performance_test.531 unable to allocate SD space from CPG cpg_zhu',
+                'resource_type' : 'Storage',
+                'location' : 'sw_vv:20656:LUN_performance_test.899',
+                'storage_id' : '4ec28b27-0d3d-4876-8da7-a16876ea489c',
+                'storage_name' : 'HPEDevice',
+                'vendor' : 'HPE',
+                'model' : 'HP_3PAR 8450',
+                'serial_number' : 'XXYYZZ1234'
+            },
+            {
+                'alert_id' : '255912',
+                'alert_name' : 'Storage Array Usable Free Space is less than 20%',
+                'severity' : 'Critical',
+                'category' : 'Fault',
+                'type' : 'EquipmentAlarm',
+                'sequence_number' : 658,
+                'occur_time' : 1514140673010,
+                'description' : 'Storage Array Usable Free Space is less than 20% was triggered.',
+                'resource_type' : 'Storage',
+                'location' : 'sw_vv:20656:LUN_performance_test.900',
+                'storage_id' : '4ec28b27-0d3d-4876-8da7-a16876ea479c',
+                'storage_name' : 'DellVMAX250F',
+                'vendor' : 'Dell EMC',
+                'model' : 'VMAX250F',
+                'serial_number' : 'XXYY5678'
+            },
+            {
+                'alert_id' : '255915',
+                'alert_name' : 'Pool Usable Free Space is less than 20%',
+                'severity' : 'Warning',
+                'category' : 'Fault',
+                'type' : 'EquipmentAlarm',
+                'sequence_number' : 659,
+                'occur_time' : 1514140674050,
+                'description' : 'Pool Usable Free Space is less than 20% was triggered.',
+                'resource_type' : 'Storage',
+                'location' : 'sw_vv:20656:LUN_performance_test.900',
+                'storage_id' : '4ec28b27-0d3d-4876-8da7-a16876ea479c',
+                'storage_name' : 'OceanStorV3',
+                'vendor' : 'Huawei',
+                'model' : 'OceanStor V3',
+                'serial_number' : 'XXYY9101'
+            },
+            {
+                'alert_id' : '255811',
+                'alert_name' : 'TP VV allocation failure',
+                'severity' : 'Critical',
+                'category' : 'Fault',
+                'type' : 'EquipmentAlarm',
+                'sequence_number' : 657,
+                'occur_time' : 1514140673000,
+                'description' : 'Thin provisioned VV LUN_performance_test.531 unable to allocate SD space from CPG cpg_zhu',
+                'resource_type' : 'Storage',
+                'location' : 'sw_vv:20656:LUN_performance_test.899',
+                'storage_id' : '4ec28b27-0d3d-4876-8da7-a16876ea489c',
+                'storage_name' : 'HPEDevice',
+                'vendor' : 'HPE',
+                'model' : 'HP_3PAR 8450',
+                'serial_number' : 'XXYYZZ1234'
+            },
+            {
+                'alert_id' : '255812',
+                'alert_name' : 'Storage Array Usable Free Space is less than 20%',
+                'severity' : 'Critical',
+                'category' : 'Fault',
+                'type' : 'EquipmentAlarm',
+                'sequence_number' : 658,
+                'occur_time' : 1514140673010,
+                'description' : 'Storage Array Usable Free Space is less than 20% was triggered.',
+                'resource_type' : 'Storage',
+                'location' : 'sw_vv:20656:LUN_performance_test.900',
+                'storage_id' : '4ec28b27-0d3d-4876-8da7-a16876ea479c',
+                'storage_name' : 'DellVMAX250F',
+                'vendor' : 'Dell EMC',
+                'model' : 'VMAX250F',
+                'serial_number' : 'XXYY5678'
+            },
+            {
+                'alert_id' : '255815',
+                'alert_name' : 'Pool Usable Free Space is less than 20%',
+                'severity' : 'Warning',
+                'category' : 'Fault',
+                'type' : 'EquipmentAlarm',
+                'sequence_number' : 659,
+                'occur_time' : 1514140674050,
+                'description' : 'Pool Usable Free Space is less than 20% was triggered.',
+                'resource_type' : 'Storage',
+                'location' : 'sw_vv:20656:LUN_performance_test.900',
+                'storage_id' : '4ec28b27-0d3d-4876-8da7-a16876ea479c',
+                'storage_name' : 'OceanStorV3',
+                'vendor' : 'Huawei',
+                'model' : 'OceanStor V3',
+                'serial_number' : 'XXYY9101'
+            }
+        ); */
+        // FIXME ALERTS DUMMY DATA
+    }
+}

--- a/src/app/business/delfin/storage-details/storage-details.module.ts
+++ b/src/app/business/delfin/storage-details/storage-details.module.ts
@@ -1,0 +1,54 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+
+import { StorageDetailsComponent } from './storage-details.component';
+import { StorageVolumesComponent } from '../volumes/volumes.component';
+import { StoragePoolsComponent } from '../storage-pools/storage-pools.component';
+import { HttpService } from '../../../shared/api';
+import { ProfileService } from '../../profile/profile.service';
+import { AvailabilityZonesService } from '../../resource/resource.service';
+import { DelfinService } from '../delfin.service';
+import { TabViewModule, PanelModule, DataTableModule, ChartModule, OverlayPanelModule, CardModule, InputTextModule, CheckboxModule, ButtonModule, SplitButtonModule, DropdownModule, MultiSelectModule, DialogModule, Message, GrowlModule, SpinnerModule, FormModule } from '../../../components/common/api';
+import { TooltipModule } from '../../../components/tooltip/tooltip';
+import { ProgressBarModule } from '../../../components/progressbar/progressbar';
+let routers = [{
+  path: '',
+  component: StorageDetailsComponent
+}]
+
+@NgModule({
+  imports: [
+    RouterModule.forChild(routers),
+    ReactiveFormsModule,
+    FormsModule,
+    CommonModule,
+    TabViewModule,
+    PanelModule,
+    DataTableModule,
+    ChartModule,
+    OverlayPanelModule,
+    CardModule,
+    InputTextModule,
+    CheckboxModule,
+    ButtonModule,
+    SplitButtonModule,
+    DropdownModule,
+    MultiSelectModule,
+    DialogModule,
+    GrowlModule,
+    SpinnerModule,
+    FormModule,
+    TooltipModule,
+    ProgressBarModule
+  ],
+  declarations: [ StorageDetailsComponent, StorageVolumesComponent, StoragePoolsComponent ],
+  providers: [
+    HttpService,
+    ProfileService,
+    AvailabilityZonesService,
+    DelfinService
+  ]
+})
+export class StorageDetailsModule { }

--- a/src/app/business/delfin/storage-pools/storage-pools.component.html
+++ b/src/app/business/delfin/storage-pools/storage-pools.component.html
@@ -1,0 +1,262 @@
+<div class="table-toolbar">
+    <div class="left">
+    </div>
+    <div class="right">
+        <div  class="ui-inputsearch">
+            <input type="text" #searchAll pInputText placeholder="{{i18n.keyID['sds_block_volume_search']}}">
+            <button pButton type="button" icon="fa-search"></button>
+        </div>
+    </div>
+</div>
+<p-dataTable [value]="poolsArr" [globalFilter]="searchAll"  [lazy]="true" (onLazyLoad)="loadPoolsLazy($event)" [expandableRows]="true"  [rows]="10" [paginator]="true" [pageLinks]="3" [rowsPerPageOptions]="[10,20,50,100]" [totalRecords]="totalRecords" #spt>
+    <p-column expander="true" styleClass="col-icon" [style]="{'width': '3%'}"></p-column>
+    <p-column field="name" header="Name">
+        <ng-template pTemplate="body" let-pool="rowData">
+            <a (mouseenter)="showPoolOverview($event, pool, poolOverviewPanel)" (mouseleave)="showPoolOverview($event, pool, poolOverviewPanel)">{{pool.name}}</a>
+        </ng-template>
+    </p-column>    
+    <p-column field="status" header="Status" [style]="{'width': '8%'}">
+        <ng-template pTemplate="body" let-pool="rowData">
+            <span class="storage-status-icon" [ngClass]="{normal: pool.status=='normal', abnormal: pool.status=='abnormal' || pool.status=='offline'}"><i class="fa fa-circle"></i></span>
+            <span *ngIf="pool.status=='normal'">Normal</span>
+            <span *ngIf="pool.status=='abnormal'">Abnormal</span>
+            <span *ngIf="pool.status=='offline'">Offline</span>
+        </ng-template>
+    </p-column>
+    <p-column field="created_at" header="Created At">
+        <ng-template pTemplate="body" let-pool="rowData">
+            <span>{{pool.created_at ? (pool.created_at | date:'long') : '--'}}</span>
+        </ng-template>
+    </p-column>
+    <p-column field="updated_at" header="Updated At">
+        <ng-template pTemplate="body" let-pool="rowData">
+            <span>{{pool.updated_at ? (pool.updated_at | date:'long') : '--'}}</span>
+        </ng-template>
+    </p-column>
+    <ng-template let-pool pTemplate="rowexpansion">
+        <div class="details-basic-info">
+            <div class="ui-grid ui-grid-responsive ui-grid-pad ui-fluid">
+                <div class="ui-grid-col-12">
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.name}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="pool">
+                            {{pool.name}}
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.status}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="pool">
+                            <span class="storage-status-icon" [ngClass]="{normal: pool.status=='normal', abnormal: pool.status=='abnormal' || pool.status=='offline'}"><i class="fa fa-circle"></i></span>
+                            <span *ngIf="pool.status=='normal'">Normal</span>
+                            <span *ngIf="pool.status=='abnormal'">Abnormal</span>
+                            <span *ngIf="pool.status=='offline'">Offline</span>
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.created_at}}:
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="pool">
+                            {{pool.created_at ? (pool.created_at | date:'long') : '--'}}
+                        </div>
+                    
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.id}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="pool">
+                            {{pool.id | slice:0:20}}
+                            <a *ngIf="pool.id.length > 20" pTooltip="{{pool.id}}" tooltipPosition="top">
+                                ...
+                            </a>
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.native_storage_pool_id}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="pool">
+                            {{pool.native_storage_pool_id | slice:0:20}}
+                            <a *ngIf="pool.native_storage_pool_id.length > 20" pTooltip="{{pool.native_storage_pool_id}}" tooltipPosition="top">
+                                ...
+                            </a>
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.updated_at}}:
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="pool">
+                            {{pool.updated_at ? (pool.updated_at | date:'long') : '--'}}
+                        </div>
+                        
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                            <div class="ui-grid-col-2">
+                                {{label.storage_id}}:
+                            </div>
+                            <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="pool">
+                                {{pool.storage_id | slice:0:20}}
+                                <a *ngIf="pool.storage_id.length > 20" pTooltip="{{pool.storage_id}}" tooltipPosition="top">
+                                    ...
+                                </a>
+                            </div>
+                            <div class="ui-grid-col-2">
+                                {{label.storage_type}}:
+                            </div>
+                            <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="pool">
+                                {{pool.storage_type ? pool.storage_type : '--'}}
+                            </div>
+                            
+                            <div class="ui-grid-col-2">
+                                
+                            </div>
+                            <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="pool">
+                                
+                            </div>
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.description}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="pool">
+                            {{ pool.description | slice:0:20 }}
+                            <a *ngIf="pool.description.length > 20" pTooltip="{{pool.description}}" tooltipPosition="top">
+                                ...
+                            </a>
+                        </div>
+                        <div class="ui-grid-col-2">
+                            
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="pool">
+                            
+                        </div>
+                        <div class="ui-grid-col-2">
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="pool">
+                        </div>
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-12">
+                            <span>Capacity Summary</span>
+                        </div>
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.free_capacity}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="pool">
+                            {{ pool.capacity.free}}
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.used_capacity}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="pool">
+                            {{ pool.capacity.used}}
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.total_capacity}}:
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="pool">
+                            {{ pool.capacity.total}}
+                        </div>
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.subscribed_capacity}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="pool">
+                            {{ pool.capacity.subscribed ? pool.capacity.subscribed : '--'}}
+                        </div>
+                        <div class="ui-grid-col-2">
+                            
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="pool">
+                            
+                        </div>
+                        <div class="ui-grid-col-2">
+                            
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="pool">
+                            
+                        </div>
+                    </div>
+                    
+                </div>
+            </div>
+        </div>
+    </ng-template>    
+</p-dataTable>
+
+<p-overlayPanel styleClass="overview-panel" #poolOverviewPanel>
+    <div class="ui-g overview-title">
+        <h4>{{poolOverview && poolOverview.name}}</h4>
+    </div>
+    <div class="ui-g ui-g-nopad overview-item" >
+        <div class="ui-g-6">
+            <span class="overview-item-label">Status: </span>
+        </div>
+        <div class="ui-g-6">
+            <span class="storage-status-icon" [ngClass]="{normal:  poolOverview && poolOverview.status =='normal', abnormal: poolOverview && poolOverview.status =='abnormal'}"><i class="fa fa-circle"></i></span>
+            <span *ngIf="poolOverview && poolOverview.status=='normal'">Normal</span>
+            <span *ngIf=" poolOverview && poolOverview.status=='abnormal'">Abnormal</span>
+            <span *ngIf=" poolOverview && poolOverview.status=='offline'">Offline</span>
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            Vendor / Model
+        </div>
+        <div class="ui-g-6">
+            {{ selectedStorageDetails && selectedStorageDetails.vendor}} {{selectedStorageDetails && selectedStorageDetails.model}}
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            <span class="overview-item-label">
+              Storage ID  
+            </span>
+        </div>
+        <div class="ui-g-6">
+            <span>
+                {{ poolOverview && poolOverview.storage_id}}
+            </span>
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            <span class="overview-item-label">
+              Storage Serial No.  
+            </span>
+        </div>
+        <div class="ui-g-6">
+            <span>
+                {{ selectedStorageDetails && selectedStorageDetails.serial_number}}
+            </span>
+        </div>
+    </div>
+    <hr />
+    <div class="ui-g overview-item">
+        <div class="ui-g-12">
+            <span class="overview-item-label">Usable Capacity Summary</span>
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div *ngIf="poolOverview && poolOverview.capacity" class="capacity-stats-bar">
+            <table class="capacity-table" *ngIf="poolOverview && poolOverview.capacity">
+                <thead>
+                    <th class="capacity-header">Free</th>
+                    <th class="capacity-header">Used</th>
+                    <th class="capacity-header">Total</th>
+                </thead>
+                <tbody>
+                    <td class="capacity-field"><span class="free-storage">{{poolOverview.capacity && poolOverview.capacity.free ? poolOverview.capacity.free : '-'}} </span></td>
+                    <td class="capacity-field"><span class="used-storage">{{poolOverview.capacity && poolOverview.capacity.used ? poolOverview.capacity.used : '-'}} </span></td>
+                    <td class="capacity-field"><span class="total-storage">{{poolOverview.capacity && poolOverview.capacity.total ? poolOverview.capacity.total : '-'}} </span></td>
+                </tbody>
+            </table>
+            <div class="storage-usage-bar" >
+                <p-progressBar [ngClass]="{'capacity-usage-normal': poolOverview.capacity.usage < 75, 
+                    'capacity-usage-warning': poolOverview.capacity.usage > 75 && poolOverview.capacity.usage < 95, 
+                    'capacity-usage-full' : poolOverview.capacity.usage > 95 }" [value]="poolOverview.capacity.usage" unit="% used"></p-progressBar>
+            </div>
+        </div>
+    </div>
+</p-overlayPanel>

--- a/src/app/business/delfin/storage-pools/storage-pools.component.ts
+++ b/src/app/business/delfin/storage-pools/storage-pools.component.ts
@@ -1,0 +1,116 @@
+import { Component, OnInit, Input, ViewContainerRef, ViewChild, Directive, ElementRef, HostBinding, HostListener } from '@angular/core';
+import { Router, ActivatedRoute } from '@angular/router';
+import { I18NService, Utils } from 'app/shared/api';
+import { FormControl, FormGroup, FormBuilder, Validators, ValidatorFn, AbstractControl } from '@angular/forms';
+import { AppService } from 'app/app.service';
+import { I18nPluralPipe } from '@angular/common';
+import { trigger, state, style, transition, animate } from '@angular/animations';
+import { Message, MenuItem ,ConfirmationService, LazyLoadEvent} from '../../../components/common/api';
+import { DelfinService } from '../delfin.service';
+import { OverlayPanel } from 'app/components/overlaypanel/overlaypanel';
+
+
+let _ = require("underscore");
+@Component({
+    selector: 'app-delfin-storage-pools',
+    templateUrl: 'storage-pools.component.html',
+    providers: [ConfirmationService],
+    styleUrls: [],
+    animations: []
+})
+export class StoragePoolsComponent implements OnInit {
+    @Input() selectedStorage;
+    poolsArr = [];
+    allPools: any = [];
+    allStorages: any = [];
+    selectedStorageId: any;
+    selectedStorageDetails: any;
+    items: any;
+    capacityData: any;
+    dataSource: any = [];
+    totalRecords: number;
+    poolOverview: any;
+    label = {
+        name: this.i18n.keyID["sds_block_volume_name"],
+        description: this.i18n.keyID["sds_block_volume_descri"],
+        native_storage_pool_id: "Native Storage Pool ID",
+        storage_id: "Storage ID",
+        storage_type: "Storage Type",
+        status: "Status",
+        created_at: "Created At",
+        updated_at: "Updated At",
+        free_capacity: "Free Capacity",
+        used_capacity: "Used Capacity",
+        total_capacity: "Total Capacity",
+        subscribed_capacity: "Subscribed Capacity",
+        id: "Delfin ID",
+    };
+
+    constructor(
+        private ActivatedRoute: ActivatedRoute,
+        public i18n: I18NService,
+        private confirmationService: ConfirmationService,
+        private fb: FormBuilder,
+        private ds: DelfinService
+    ) {
+       
+    }
+
+    ngOnInit() {
+        this.getStorageById(this.selectedStorage);
+        this.ds.getAllStoragePools(this.selectedStorage).subscribe((res)=>{
+            this.dataSource = res.json().storage_pools;
+            
+            this.dataSource.forEach((element, index) => {
+                //Calculate the capacities for the Widgets
+                element['capacity'] = {};
+                let percentUsage = Math.ceil((element['used_capacity']/element['total_capacity']) * 100);
+                element['capacity'].used = Utils.formatBytes(element['used_capacity']);
+                element['capacity'].free = Utils.formatBytes(element['free_capacity']);
+                element['capacity'].total = Utils.formatBytes(element['total_capacity']);
+                if(element['subscribed_capacity']){
+                    element['capacity'].subscribed = Utils.formatBytes(element['subscribed_capacity']);
+                }
+                element['capacity'].usage = percentUsage;
+            });
+            
+            this.totalRecords = this.dataSource.length;
+            this.poolsArr = this.dataSource.slice(0, 10);
+            
+        }, (error)=>{
+            console.log("Something went wrong. Could not fetch Storage Pools.", error)
+        });
+    }
+
+    loadPoolsLazy(event: LazyLoadEvent){
+        if(this.dataSource){
+            this.poolsArr = this.dataSource.slice(event.first, (event.first + event.rows));
+        }
+    }
+    
+    getAllStorages(){
+        this.ds.getAllStorages().subscribe((res)=>{
+            let storages = res.json().storages;
+            this.allStorages = storages;
+        }, (error)=>{
+            console.log("Something went wrong. Could not fetch all storages", error);
+        })
+    }
+
+    getStorageById(id){
+        this.ds.getStorageById(id).subscribe((res)=>{
+            let storage = res.json();
+            this.selectedStorageDetails  = storage;
+        }, (error)=>{
+            console.log("Something went wrong. Could not fetch storage", error);
+        })
+    }
+
+    showPoolOverview(event, pool, overlaypanel: OverlayPanel){
+        this.poolOverview = pool;
+        //this.poolOverview['storageDetails'] = this.selectedStorageDetails;
+        //console.log("This is pooloverview", this.poolOverview);
+        overlaypanel.toggle(event);
+    }
+    
+}

--- a/src/app/business/delfin/storages/storages.component.html
+++ b/src/app/business/delfin/storages/storages.component.html
@@ -37,7 +37,7 @@
                     </p-header>
                     <div>
                         <p-scrollPanel [style]="{width: '100%', height: '300px'}" styleClass="storage-summary-panel-2">
-                            <p-tree [value]="arrayTreeData" [loading]="loading" [contextMenu]="cm" (onNodeExpand)="loadNode($event)" emptyMessage="No records found." [style]="{width: '100%', height: '100%', 'overflow':'auto'}">
+                            <p-tree [value]="arrayTreeData" [loading]="loading" [contextMenu]="cm" (onNodeExpand)="loadNode($event)" emptyMessage="No records found." styleClass="storage-array-tree-view" >
                                 <ng-template #modelTreeItem let-model pTemplate="modelGroup">
                                     
                                     <a (mouseenter)="showOverview($event, model, modelOverviewPanel)" (mouseleave)="showOverview($event, model, modelOverviewPanel)">{{model.label}}</a>
@@ -139,6 +139,9 @@
                                         'capacity-usage-full' : device.capacity.usage > 95 }" [value]="device.capacity.usage" unit="% used"></p-progressBar>
                                 </div>
                             </div>
+                            <div *ngIf="!allStorages.length" class="no-records-found">
+                                <span>No records found.</span>
+                            </div>
                         </p-scrollPanel>
                     </div>
                     <p-footer>
@@ -184,7 +187,9 @@
                                         </span>
                                     </div>
                                 </div>
-                                
+                            </div>
+                            <div *ngIf="!allStorages.length" class="no-records-found">
+                                <span>No records found.</span>
                             </div>
                         </p-scrollPanel>
                     </div>

--- a/src/app/business/delfin/storages/storages.component.html
+++ b/src/app/business/delfin/storages/storages.component.html
@@ -10,7 +10,7 @@
             <button pButton type="button" (click)="syncAllStorageDevices()" icon="fa-exchange" label="Sync All Devices"></button>
             <button *ngIf="showListView" pButton type="button" label="{{i18n.keyID['sds_block_volume_delete']}}" [disabled]="selectedStorages.length == 0" (click)="batchDeleteStorages(selectedStorages)"></button></div>
         <div class="right">
-            <div *ngIf="showListView" class="ui-inputsearch">
+            <div [ngStyle]="{'visibility': showListView ? 'visible' : 'hidden'}" class="ui-inputsearch">
                 <input type="text" #searchAll pInputText placeholder="{{i18n.keyID['sds_block_volume_search']}}">
                 <button pButton type="button" icon="fa-search"></button>
             </div>
@@ -28,7 +28,7 @@
                         <div class="ui-g-row summary-card-header-container" >
                             <div class="ui-g-6 left-items" style="padding-left: 0.2rem;">
                                 <div class="ui-card-title">Storage Arrays</div>
-                                <div class="ui-card-subtitle">Last updated: </div>
+                                <div class="ui-card-subtitle">Total Number of Arrays: {{allStorages.length}}</div>
                             </div>
                             <div class="ui-g-offset-4 ui-g-2">
                                 <a  (click)="toggleView()">Show all devices</a>
@@ -37,21 +37,21 @@
                     </p-header>
                     <div>
                         <p-scrollPanel [style]="{width: '100%', height: '300px'}" styleClass="storage-summary-panel-2">
-                            <p-tree [value]="arrayTreeData" [loading]="loading" emptyMessage="No records found." [style]="{width: '100%', height: '100%', 'overflow':'auto'}">
-                                <ng-template let-model pTemplate="modelGroup">
+                            <p-tree [value]="arrayTreeData" [loading]="loading" [contextMenu]="cm" (onNodeExpand)="loadNode($event)" emptyMessage="No records found." [style]="{width: '100%', height: '100%', 'overflow':'auto'}">
+                                <ng-template #modelTreeItem let-model pTemplate="modelGroup">
                                     
                                     <a (mouseenter)="showOverview($event, model, modelOverviewPanel)" (mouseleave)="showOverview($event, model, modelOverviewPanel)">{{model.label}}</a>
                                 </ng-template>
-                                <ng-template let-node pTemplate="device">
-                                    <a [routerLink]="['/storageDetails/' + node.details.id]"  (mouseenter)="showOverview($event, node, deviceOverviewPanel)" (mouseleave)="showOverview($event, node, deviceOverviewPanel)">{{node.label}}</a>
-                                    
+                                <ng-template #deviceTreeItem let-node pTemplate="device">
+                                    <a [routerLink]="['/storageDetails/' + node.details.id]" (contextmenu)="deviceNodeMenu($event, node, deviceOverviewPanel)"  (mouseenter)="showOverview($event, node, deviceOverviewPanel)" (mouseleave)="deviceOverviewPanel.hide()">{{node.label}}</a>
+                                    <i *ngIf="node.details.sync_status=='SYNCING'" title="Device is syncing" class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
                                 </ng-template>
                             </p-tree>
+                            <p-contextMenu #cm appendTo="body" [model]="contextMenuItems"></p-contextMenu>
                         </p-scrollPanel>
                     </div>
                     <p-footer>
-                        <hr />
-                        <span>Last updated: <strong> </strong></span>
+                        <span> <strong> </strong></span>
                     </p-footer>
                 </p-card>
             </div>
@@ -61,7 +61,7 @@
                         <div class="ui-g-row summary-card-header-container" >
                             <div class="ui-g-6 left-items" style="padding-left: 0.2rem;">
                                 <div class="ui-card-title">Active Alerts on Storage Objects</div>
-                                <div class="ui-card-subtitle">Last updated: </div>
+                                <div class="ui-card-subtitle"> </div>
                             </div>
                             <div class="ui-g-offset-4 ui-g-2">
                                 <a  (click)="toggleView()">Show all alerts</a>
@@ -91,8 +91,7 @@
                         </p-scrollPanel>
                     </div>
                     <p-footer>
-                        <hr />
-                        <span>Last updated: <strong> </strong></span>
+                        <span> <strong> </strong></span>
                     </p-footer>
                 </p-card>
             </div>
@@ -143,8 +142,7 @@
                         </p-scrollPanel>
                     </div>
                     <p-footer>
-                        <hr />
-                        <span>Last updated: <strong> </strong></span>
+                        <span> <strong> </strong></span>
                     </p-footer>
                 </p-card>
             </div>
@@ -201,7 +199,7 @@
     <div *ngIf="showListView">
         <div id="storage-devices-table" class="ui-g">
             <p-card  styleClass="ui-card-shadow">
-                <p-dataTable [value]="allStorages" [globalFilter]="searchAll" [(selection)]="selectedStorages" [expandableRows]="true" [showHeaderCheckbox]="true" [rows]="10" [paginator]="true" [pageLinks]="3" [rowsPerPageOptions]="[10,20,50,100]" #st>
+                <p-dataTable [value]="allStorages" [globalFilter]="searchAll" [lazy]="false" [(selection)]="selectedStorages" [expandableRows]="true" [showHeaderCheckbox]="true" [rows]="10" [paginator]="true" [pageLinks]="3" [rowsPerPageOptions]="[10,20,50,100]" #st>
                     <p-column expander="true" styleClass="col-icon" [style]="{'width': '3%'}"></p-column>
                     <p-column selectionMode="multiple" [style]="{'width': '3%'}"></p-column>
                     <p-column field="name" header="Name" [style]="{'width': '15%'}" [sortable]="true">
@@ -408,7 +406,7 @@
                 <p-header>
                     <div class="summary-card-header-container" style="padding: 0.15rem 0.2rem 0 0.2rem;">
                         <div class="ui-card-title">Active Alerts on Storage Objects</div>
-                        <div class="ui-card-subtitle">Last updated: </div>
+                        <div class="ui-card-subtitle"> </div>
                     </div>
                 </p-header>
                 <div>
@@ -433,7 +431,7 @@
                 </div>
                 <p-footer>
                     <hr />
-                    <span>Last updated: <strong> </strong></span>
+                    <span> <strong> </strong></span>
                 </p-footer>
             </p-card>
         </div>

--- a/src/app/business/delfin/storages/storages.component.html
+++ b/src/app/business/delfin/storages/storages.component.html
@@ -43,8 +43,8 @@
                                     <a (mouseenter)="showOverview($event, model, modelOverviewPanel)" (mouseleave)="showOverview($event, model, modelOverviewPanel)">{{model.label}}</a>
                                 </ng-template>
                                 <ng-template let-node pTemplate="device">
+                                    <a [routerLink]="['/storageDetails/' + node.details.id]"  (mouseenter)="showOverview($event, node, deviceOverviewPanel)" (mouseleave)="showOverview($event, node, deviceOverviewPanel)">{{node.label}}</a>
                                     
-                                    <a (mouseenter)="showOverview($event, node, deviceOverviewPanel)" (mouseleave)="showOverview($event, node, deviceOverviewPanel)">{{node.label}}</a>
                                 </ng-template>
                             </p-tree>
                         </p-scrollPanel>
@@ -548,7 +548,7 @@
     <hr />
     <div class="ui-g overview-item">
         <div class="ui-g-12">
-            <span class="overview-item-label">Usable Capacity Summary (F / U / T)</span>
+            <span class="overview-item-label">Usable Capacity Summary</span>
         </div>
     </div>
     <div class="ui-g overview-item">

--- a/src/app/business/delfin/storages/storages.component.ts
+++ b/src/app/business/delfin/storages/storages.component.ts
@@ -28,6 +28,7 @@ export class StoragesComponent implements OnInit {
     selectStorage;
     showListView: boolean = false;
     menuItems: MenuItem[];
+    contextMenuItems: MenuItem[];
     capacityData: any;
     chartOptions: any;
     vendorOptions;
@@ -454,10 +455,22 @@ export class StoragesComponent implements OnInit {
                                 }
                                 modelTreeNode['children'].push(parentVolNode);
                             }
-
+                            let volChildNode ={};
+                            if(storageDevice['volumes'].length){
+                                _.each(storageDevice['volumes'], function(volItem){
+                                    volChildNode = {
+                                        label : volItem['name'],
+                                        collapsedIcon: 'fa-database',
+                                        expandedIcon: 'fa-database',
+                                        type: 'volNode',
+                                        details: volItem
+                                    }
+                                })
+                                
+                            }
                             // Create the Storage Pool parent Node
                             let parentPoolNode = {};
-                            if(storageDevice['storagePools'] ){
+                            if(storageDevice['storagePools']){
                                 parentPoolNode = {
                                     label : "Storage Pools",
                                     collapsedIcon: 'fa-cubes',
@@ -490,6 +503,50 @@ export class StoragesComponent implements OnInit {
         this.arrayTreeData = treeData;
         
     }
+    public deviceNodeMenu(event, node, overlaypanel: OverlayPanel) {
+       overlaypanel.hide();
+        if(node['type']='device'){
+            this.contextMenuItems = [
+                {
+                    "label": "Register Alert Source",
+                    command: () => {
+                        this.showAlertSourceDialog(node['details']);
+                    },
+                    disabled:false
+                },
+                
+                {
+                    "label": "Remove Alert Source",
+                    command: () => {
+                        
+                        console.log("Alert Source removed");
+                    	//TODO: Add remove alert source
+                    },
+                    disabled:false
+                },
+                {
+                    "label": "Sync Storage Device",
+                    command: () => {
+                        this.syncStorage(node['details'].id);
+                    },
+                    disabled:false
+                },
+                {
+                    "label": this.i18n.keyID['sds_block_volume_delete'],
+                    command: () => {
+                        this.batchDeleteStorages(node['details']);
+                    },
+                    disabled:false
+                }
+            ];
+        } else{
+            this.contextMenuItems = [];
+        }
+        
+        return false;
+    }
+
+
 
     showChart(){
         

--- a/src/app/business/delfin/volumes/volumes.component.html
+++ b/src/app/business/delfin/volumes/volumes.component.html
@@ -1,0 +1,240 @@
+<div class="table-toolbar">
+    <div class="left">
+    </div>
+    <div class="right">
+        <div  class="ui-inputsearch">
+            <input type="text" #searchAll pInputText placeholder="{{i18n.keyID['sds_block_volume_search']}}">
+            <button pButton type="button" icon="fa-search"></button>
+        </div>
+    </div>
+</div>
+<p-dataTable [value]="volumesArr" [globalFilter]="searchAll" [lazy]="true" (onLazyLoad)="loadVolumesLazy($event)" [rows]="10" [expandableRows]="true" [paginator]="true" [pageLinks]="3" [rowsPerPageOptions]="[10,20,50,100]" [totalRecords]="totalRecords" #vt>
+    <p-column expander="true" styleClass="col-icon" [style]="{'width': '3%'}"></p-column>
+    <p-column field="name" header="Name" #volumeName>
+        <ng-template pTemplate="body" let-volume="rowData">
+            <a (mouseenter)="showVolumeOverview($event, volume, volumeOverviewPanel)" (mouseleave)="showVolumeOverview($event, volume, volumeOverviewPanel)">{{volume.name}}</a>
+        </ng-template>
+    </p-column>    
+    <p-column field="wwn" header="WWN"></p-column> 
+    <p-column field="status" header="Status" [style]="{'width': '8%'}">
+        <ng-template pTemplate="body" let-volume="rowData">
+            <span class="storage-status-icon" [ngClass]="{normal: volume.status=='normal', abnormal: volume.status=='abnormal' || volume.status=='offline'}"><i class="fa fa-circle"></i></span>
+            <span *ngIf="volume.status=='normal'">Normal</span>
+            <span *ngIf="volume.status=='abnormal'">Abnormal</span>
+            <span *ngIf="volume.status=='offline'">Offline</span>
+        </ng-template>
+    </p-column>
+    <p-column field="created_at" header="Created At">
+        <ng-template pTemplate="body" let-volume="rowData">
+            <span>{{volume.created_at ? (volume.created_at | date:'long') : '--'}}</span>
+        </ng-template>
+    </p-column>
+    <p-column field="updated_at" header="Updated At">
+        <ng-template pTemplate="body" let-volume="rowData">
+            <span>{{volume.updated_at ? (volume.updated_at | date:'long') : '--'}}</span>
+        </ng-template>
+    </p-column>
+    <ng-template let-volume pTemplate="rowexpansion">
+        <div class="details-basic-info">
+            <div class="ui-grid ui-grid-responsive ui-grid-pad ui-fluid">
+                <div class="ui-grid-col-12">
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.name}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="volume">
+                            {{volume.name}}
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.status}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="volume">
+                            <span class="storage-status-icon" [ngClass]="{normal: volume.status=='normal', abnormal: volume.status=='abnormal' || volume.status=='offline'}"><i class="fa fa-circle"></i></span>
+                            <span *ngIf="volume.status=='normal'">Normal</span>
+                            <span *ngIf="volume.status=='abnormal'">Abnormal</span>
+                            <span *ngIf="volume.status=='offline'">Offline</span>
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.wwn}}:
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="volume">
+                            {{volume.wwn}}
+                        </div>
+                    
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.id}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="volume">
+                            {{volume.id | slice:0:20}}
+                            <a *ngIf="volume.id.length > 20" pTooltip="{{volume.id}}" tooltipPosition="top">
+                                ...
+                            </a>
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.native_volume_id}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="volume">
+                            {{volume.native_volume_id | slice:0:20}}
+                            <a *ngIf="volume.native_volume_id.length > 20" pTooltip="{{volume.native_volume_id}}" tooltipPosition="top">
+                                ...
+                            </a>
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.created_at}}:
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="volume">
+                            {{volume.created_at ? (volume.created_at | date:'long') : '--'}}
+                        </div>
+                        
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                            <div class="ui-grid-col-2">
+                                {{label.compressed}}
+                            </div>
+                            <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="volume">
+                                {{volume.compressed ? volume.compressed : '--'}}
+                            </div>
+                            <div class="ui-grid-col-2">
+                                {{label.deduplicated}}:
+                            </div>
+                            <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="volume">
+                                {{ volume.deduplicated ? volume.deduplicated : '--'}}
+                            </div>
+                            
+                            <div class="ui-grid-col-2">
+                                {{label.updated_at}}:
+                            </div>
+                            <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="volume">
+                                {{volume.updated_at ? (volume.updated_at | date:'long') : '--'}}
+                            </div>
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.description}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="volume">
+                            {{ volume.description | slice:0:20 }}
+                            <a *ngIf="volume.description.length > 20" pTooltip="{{volume.description}}" tooltipPosition="top">
+                                ...
+                            </a>
+                        </div>
+                        <div class="ui-grid-col-2">
+                            
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="volume">
+                            
+                        </div>
+                        <div class="ui-grid-col-2">
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="volume">
+                        </div>
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-12">
+                            <span>Capacity Summary</span>
+                        </div>
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.free_capacity}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="volume">
+                            {{ volume.capacity.free}}
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.used_capacity}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="volume">
+                            {{ volume.capacity.used}}
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.total_capacity}}:
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="volume">
+                            {{ volume.capacity.total}}
+                        </div>
+                    </div>
+                    
+                </div>
+            </div>
+        </div>
+    </ng-template>   
+</p-dataTable>
+
+<p-overlayPanel styleClass="overview-panel" #volumeOverviewPanel>
+    <div class="ui-g overview-title">
+        <h4>{{volumeOverview && volumeOverview.name}}</h4>
+    </div>
+    <div class="ui-g ui-g-nopad overview-item" >
+        <div class="ui-g-6">
+            <span class="overview-item-label">Status: </span>
+        </div>
+        <div class="ui-g-6">
+            <span class="storage-status-icon" [ngClass]="{normal:  volumeOverview && volumeOverview.status =='normal', abnormal: volumeOverview && volumeOverview.status =='abnormal'}"><i class="fa fa-circle"></i></span>
+            <span *ngIf="volumeOverview && volumeOverview.status=='normal'">Normal</span>
+            <span *ngIf=" volumeOverview && volumeOverview.status=='abnormal'">Abnormal</span>
+            <span *ngIf=" volumeOverview && volumeOverview.status=='offline'">Offline</span>
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            Vendor / Model
+        </div>
+        <div class="ui-g-6">
+            {{ selectedStorageDetails && selectedStorageDetails.vendor}} {{selectedStorageDetails && selectedStorageDetails.model}}
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            <span class="overview-item-label">
+              Storage ID  
+            </span>
+        </div>
+        <div class="ui-g-6">
+            <span>
+                {{ volumeOverview && volumeOverview.storage_id}}
+            </span>
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            <span class="overview-item-label">
+              Storage Serial No.  
+            </span>
+        </div>
+        <div class="ui-g-6">
+            <span>
+                {{ selectedStorageDetails && selectedStorageDetails.serial_number}}
+            </span>
+        </div>
+    </div>
+    <hr />
+    <div class="ui-g overview-item">
+        <div class="ui-g-12">
+            <span class="overview-item-label">Usable Capacity Summary</span>
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div *ngIf="volumeOverview && volumeOverview.capacity" class="capacity-stats-bar">
+            <table class="capacity-table" *ngIf="volumeOverview && volumeOverview.capacity">
+                <thead>
+                    <th class="capacity-header">Free</th>
+                    <th class="capacity-header">Used</th>
+                    <th class="capacity-header">Total</th>
+                </thead>
+                <tbody>
+                    <td class="capacity-field"><span class="free-storage">{{volumeOverview.capacity && volumeOverview.capacity.free ? volumeOverview.capacity.free : '-'}} </span></td>
+                    <td class="capacity-field"><span class="used-storage">{{volumeOverview.capacity && volumeOverview.capacity.used ? volumeOverview.capacity.used : '-'}} </span></td>
+                    <td class="capacity-field"><span class="total-storage">{{volumeOverview.capacity && volumeOverview.capacity.total ? volumeOverview.capacity.total : '-'}} </span></td>
+                </tbody>
+            </table>
+            <div class="storage-usage-bar" >
+                <p-progressBar [ngClass]="{'capacity-usage-normal': volumeOverview.capacity.usage < 75, 
+                    'capacity-usage-warning': volumeOverview.capacity.usage > 75 && volumeOverview.capacity.usage < 95, 
+                    'capacity-usage-full' : volumeOverview.capacity.usage > 95 }" [value]="volumeOverview.capacity.usage" unit="% used"></p-progressBar>
+            </div>
+        </div>
+    </div>
+</p-overlayPanel>

--- a/src/app/business/delfin/volumes/volumes.component.ts
+++ b/src/app/business/delfin/volumes/volumes.component.ts
@@ -1,0 +1,111 @@
+import { Component, OnInit, Input, ViewContainerRef, ViewChild, Directive, ElementRef, HostBinding, HostListener } from '@angular/core';
+import { Router, ActivatedRoute } from '@angular/router';
+import { I18NService, Utils } from 'app/shared/api';
+import { FormControl, FormGroup, FormBuilder, Validators, ValidatorFn, AbstractControl } from '@angular/forms';
+import { AppService } from 'app/app.service';
+import { I18nPluralPipe } from '@angular/common';
+import { trigger, state, style, transition, animate } from '@angular/animations';
+import { Message, MenuItem ,ConfirmationService, LazyLoadEvent} from '../../../components/common/api';
+import { DelfinService } from '../delfin.service';
+import { OverlayPanel } from 'app/components/overlaypanel/overlaypanel';
+
+
+let _ = require("underscore");
+@Component({
+    selector: 'app-delfin-volumes',
+    templateUrl: 'volumes.component.html',
+    providers: [ConfirmationService],
+    styleUrls: [],
+    animations: []
+})
+export class StorageVolumesComponent implements OnInit {
+    @Input() selectedStorage;
+    volumesArr = [];
+    allVolumes: any = [];
+    allStorages: any = [];
+    selectedStorageId: any;
+    selectedStorageDetails: any;
+    items: any;
+    capacityData: any;
+    dataSource: any = [];
+    totalRecords: number;
+    volumeOverview: any;
+    label = {
+        name: this.i18n.keyID["sds_block_volume_name"],
+        description: this.i18n.keyID["sds_block_volume_descri"],
+        wwn: "WWN",
+        native_volume_id: "Native Volume ID",
+        storage_id: "Storage ID",
+        compressed: "Compressed",
+        deduplicated: "Deduplicated",
+        status: "Status",
+        created_at: "Created At",
+        updated_at: "Updated At",
+        free_capacity: "Free Capacity",
+        used_capacity: "Used Capacity",
+        total_capacity: "Total Capacity",
+        id: "Delfin ID",
+    };
+
+    constructor(
+        private ActivatedRoute: ActivatedRoute,
+        public i18n: I18NService,
+        private confirmationService: ConfirmationService,
+        private fb: FormBuilder,
+        private ds: DelfinService
+    ) {
+     }
+
+    ngOnInit() {
+        this.getStorageById(this.selectedStorage);
+        this.ds.getAllVolumes(this.selectedStorage).subscribe((res)=>{
+            this.dataSource = res.json().volumes;
+            
+            this.dataSource.forEach((element, index) => {
+                //Calculate the capacities for the Widgets
+                element['capacity'] = {};
+                let percentUsage = Math.ceil((element['used_capacity']/element['total_capacity']) * 100);
+                element['capacity'].used = Utils.formatBytes(element['used_capacity']);
+                element['capacity'].free = Utils.formatBytes(element['free_capacity']);
+                element['capacity'].total = Utils.formatBytes(element['total_capacity']);
+                element['capacity'].usage = percentUsage;
+            });
+            
+            this.totalRecords = this.dataSource.length;
+            this.volumesArr = this.dataSource.slice(0, 10);
+            
+        }, (error)=>{
+            console.log("Something went wrong. Could not fetch Volumes.", error)
+        });
+    }
+
+    loadVolumesLazy(event: LazyLoadEvent){
+        if(this.dataSource){
+            this.volumesArr = this.dataSource.slice(event.first, (event.first + event.rows));
+        }
+    }
+    
+    getAllStorages(){
+        this.ds.getAllStorages().subscribe((res)=>{
+            let storages = res.json().storages;
+            this.allStorages = storages;
+        }, (error)=>{
+            console.log("Something went wrong. Could not fetch all storages", error);
+        })
+    }
+
+    getStorageById(id){
+        this.ds.getStorageById(id).subscribe((res)=>{
+            let storage = res.json();
+            this.selectedStorageDetails  = storage;
+        }, (error)=>{
+            console.log("Something went wrong. Could not fetch storage", error);
+        })
+    }
+
+    showVolumeOverview(event, volume, overlaypanel: OverlayPanel){
+        this.volumeOverview = volume;
+        overlaypanel.toggle(event);
+    }
+    
+}

--- a/src/app/shared/utils/utils.ts
+++ b/src/app/shared/utils/utils.ts
@@ -1,5 +1,5 @@
 import {ValidatorFn, AbstractControl } from '@angular/forms';
-import { Consts } from '../../shared/api';
+import { Consts } from './consts';
 export class Utils {
 
     static capacityUnit = {

--- a/src/assets/business/css/site.scss
+++ b/src/assets/business/css/site.scss
@@ -2201,7 +2201,7 @@ dl.storage-capacity-list dd{
         background: #26988f;
     }
     .capacity-usage-normal .ui-progressbar-label{
-        color: #fff;
+        color: #000;
         padding-top: 2px;
     }
 }

--- a/src/assets/business/css/site.scss
+++ b/src/assets/business/css/site.scss
@@ -2158,6 +2158,20 @@ a.remove-initiator, a.remove-tag, a.remove-metadata, a.remove-extra-attribute{
 }
 /* Help Section Ends */
 /* Delfin Styles start */
+td.ui-datatable-emptymessage{
+    text-align: center;
+}
+.storage-array-tree-view {
+    width: 100%;
+    height: 100%; 
+    overflow: auto;
+
+    .ui-tree-empty-message {
+        padding: .25em;
+        text-align: center;
+        padding-top: 1.5rem;
+    }
+}
 .delfin-storage-list-page .ui-dataview-layout-options.ui-selectbutton .ui-togglebutton.ui-button.ui-state-default, .ui-selectbutton .ui-button.ui-state-default{
 padding: 0 0.15rem;
 }
@@ -2179,6 +2193,10 @@ dl.storage-capacity-list dd{
     min-height: 350px;
     .ui-scrollpanel-content{
         height: calc(100%);
+    }
+    .no-records-found {
+        text-align: center;
+        padding-top: 2rem;
     }
 }
 .storage-status-icon i{

--- a/src/assets/business/css/site.scss
+++ b/src/assets/business/css/site.scss
@@ -2177,6 +2177,9 @@ dl.storage-capacity-list dd{
 .storage-summary-panel-2{
     height: 400px;
     min-height: 350px;
+    .ui-scrollpanel-content{
+        height: calc(100%);
+    }
 }
 .storage-status-icon i{
     font-size: 0.12rem;
@@ -2311,6 +2314,38 @@ dl.storage-capacity-list dd{
             }
         }
     }
+}
+
+.ui-grid-row .capacity-overview-container {
+    box-shadow: 5px 5px 25px rgba(51, 59, 69, 0.14902);
+    -webkit-box-shadow: 10px 5px 25px rgba(51, 59, 69, 0.14902);
+    -moz-box-shadow: 5px 5px 25px rgba(51, 59, 69, 0.14902);
+    border: 1px solid #D5D5D5;
+    background-color: #1D7CEC;
+    color: #657D95;
+    border: 25px solid #fff;
+}
+.capacity-overview-container.free{
+    background-color: #67B214;
+}
+.capacity-overview-container.used{
+    background-color: #db4437;
+}
+.capacity-overview-container.raw{
+    background-color: #48917b;
+}
+.capacity-overview-container.system-used{
+    background-color: #444;
+}
+.capacity-overview-container.subscribed{
+    background-color: #134d8e;
+}
+.capacity-overview-label-tile, .capacity-overview-value-tile {
+    color: #fff;
+    text-align: center;
+    padding: 20px 5px;
+    font-size: 1.25em;
+    font-weight: 600;
 }
 /* Delfin Styles end */
 


### PR DESCRIPTION
**What type of PR is this?**
/kind new feature
**What this PR does / why we need it**:
This PR lets the user view the details of a storage array on clicking the name of the storage device in the tree view, usable capacity widget, raw capacity widget and any other location where the storage device name can be linked.
This PR adds the following to the view:
- Storage array configuration overview
- Sync Storage device
- List all volumes associated with the array
- Expand the single volume to show details
- Hover on a volume to get quick overview
- List all pools associated with the array
- Expand the single pool to show details
- Hover on a pool to get quick overview
- Capacity tab with Chart view depicting current Usable Capacity
- Capacity tab with Chart view depicting current Raw Capacity
- Capacity Tab with charts for volumes and Storage pools capacity usage
- Alerts Tab listing latest alerts for storage device.
- Context menu support in the tree view in the storage summary page.
- Device Syncing status shown in tree view.

This PR also has some fixes in the code to remove redundant and unused code and corrected API calls to fetch volumes and storage pools by storage ID.

**Which issue(s) this PR fixes**:
Fixes #: 
#391 
- [x] Resources (Volumes, Storage Pools)
- [x]  Alerts
- [x]  Capacity Usage 
- [x]  Configuration information.  

#394 #396 #397 

**Test Report Added?**:
/kind TESTED


**Test Report**:
**Storage Array Details Overview - Configuration Tab**
![details-overview-1](https://user-images.githubusercontent.com/19162717/93230768-aba31180-f795-11ea-89c2-4e105487b6e1.png)

**Storage Array Syncing and trigger**
![details-overview-syncing](https://user-images.githubusercontent.com/19162717/93230771-ac3ba800-f795-11ea-9e99-c0504a68ec1b.png)

**List all Volumes**
![details-list-volumes](https://user-images.githubusercontent.com/19162717/93230759-a80f8a80-f795-11ea-8ff9-7ea4bbe11e04.png)

**Expand Volume Details**
![details-list-volumes-expand-details](https://user-images.githubusercontent.com/19162717/93230763-a940b780-f795-11ea-949c-29354d979978.png)

**Hover on Volume Name for quick overview**
![details-list-volumes-hover-overview-1](https://user-images.githubusercontent.com/19162717/93230766-aa71e480-f795-11ea-9bbf-5ee8d9e008b9.png)

![details-list-volumes-hover-overview-2](https://user-images.githubusercontent.com/19162717/93230767-ab0a7b00-f795-11ea-8fc7-6be3235fe3c6.png)

**List all Pools**
![details-list-pools](https://user-images.githubusercontent.com/19162717/93230653-88786200-f795-11ea-96cd-c79e49ba910f.png)

**Expand Pool Details**
![details-list-pools-expand-details](https://user-images.githubusercontent.com/19162717/93231832-cd50c880-f796-11ea-87f7-b28ea3e32e63.png)

**Hover on Volume Name for quick overview**
![details-list-pools-hover-overview-1](https://user-images.githubusercontent.com/19162717/93230745-a3e36d00-f795-11ea-9a29-ec7990935403.png)

![details-list-pools-hover-overview-2](https://user-images.githubusercontent.com/19162717/93230754-a645c700-f795-11ea-94d5-b503ffd451c7.png)

**Capacity Overview tab with Charts**

**Quick Capacity Usage Number**
![capacity-dashboard-1](https://user-images.githubusercontent.com/19162717/93358329-f8065400-f85e-11ea-872c-0e7b136256c4.png)

**Volumes and Storage pools capacity usage**
![capacity-dashboard-2](https://user-images.githubusercontent.com/19162717/93358338-fb014480-f85e-11ea-94bb-3e7db9536668.png)

**List Storage array alerts**
![details-alerts-tab](https://user-images.githubusercontent.com/19162717/93230610-7d253680-f795-11ea-9537-0f27b5145465.png)

**Added context menu to the Storage Device Tree view to allow user to perform the same device operations from the table list view.**
![tree-context-menu](https://user-images.githubusercontent.com/19162717/93432028-95569c00-f8e2-11ea-9f92-3a579be78895.png)

**Added Syncing status view in the tree view for devices.**
![tree-syncing-icon](https://user-images.githubusercontent.com/19162717/93432090-ab645c80-f8e2-11ea-99f8-306b912b7c8a.png)



**Special notes for your reviewer**:
