### PR TITLE
Add support for Huawei EVS to SODA Dashboard multicloud block service

### DIFF
--- a/src/app/business/block/cloud-block-service/cloud-block-service.component.html
+++ b/src/app/business/block/cloud-block-service/cloud-block-service.component.html
@@ -19,7 +19,7 @@
         <p-column field="name" header="Name"></p-column>
         <p-column field="size" header="Size">
             <ng-template pTemplate="body" let-volume="rowData">
-                {{volume.displaySize}}
+                {{volume.displaySize ? volume.displaySize : '--'}}
             </ng-template>
         </p-column>
         <p-column field="iops" header="IOPS">

--- a/src/app/business/block/cloud-block-service/cloud-block-service.component.ts
+++ b/src/app/business/block/cloud-block-service/cloud-block-service.component.ts
@@ -77,28 +77,7 @@ export class CloudBlockServiceComponent implements OnInit{
 
     ngOnInit(){
         
-        this.volumeTypeOptions = [
-            {
-                label: 'General Purpose',
-                value: 'gp2'
-            },
-            {
-                label: 'Provisioned IOPS',
-                value: 'io1'
-            },
-            {
-                label: 'Cold HDD',
-                value: 'sc1'
-            },
-            {
-                label: 'Throughput Optimized',
-                value: 'st1'
-            },
-            {
-                label: 'Magnetic(Standard)',
-                value: 'standard'
-            }
-        ];
+        this.volumeTypeOptions = this.volumeTypeOptions.concat(Consts.AWS_VOLUME_TYPES, Consts.HW_VOLUME_TYPES);
         this.getTypes();
         this.getBackends();
         
@@ -124,7 +103,7 @@ export class CloudBlockServiceComponent implements OnInit{
         this.allTypes = [];
         this.BucketService.getTypes().subscribe((res) => {
             res.json().types.forEach(element => {
-            if( element.name=='aws-block'){
+            if( element.name=='aws-block' || element.name=='hw-block'){
                 this.allTypes.push({
                     label: Consts.CLOUD_TYPE_NAME[element.name],
                     value: element.name
@@ -142,7 +121,7 @@ export class CloudBlockServiceComponent implements OnInit{
         this.http.get('v1/{project_id}/backends').subscribe((res)=>{
             this.allBackends = res.json().backends ? res.json().backends :[];
             this.allBackends.forEach(element => {
-                if(element.type == 'aws-block'){
+                if(element.type == 'aws-block' || element.type == 'hw-block'){
                     this.selectedBackends.push(element);
                 }
             });
@@ -163,8 +142,10 @@ export class CloudBlockServiceComponent implements OnInit{
             this.allAWSVolumes = vols;
             
             this.allAWSVolumes.forEach(volElement => {
-                this.volumeTypeOptions.forEach(typeEle => {
+                if(volElement['size'] && volElement['size'] > 0){
                     volElement['displaySize'] = Utils.formatBytes([volElement['size']]);
+                }
+                this.volumeTypeOptions.forEach(typeEle => {
                     if(typeEle['value'] == volElement['type']){
                         volElement['volType'] = typeEle['label'];
                     }

--- a/src/app/business/block/cloud-block-service/create/cloud-volume-create.component.html
+++ b/src/app/business/block/cloud-block-service/create/cloud-volume-create.component.html
@@ -4,17 +4,17 @@
 </div>
 
 <form [grid]="{label: 'ui-g-3', content:'ui-g-20'}" [formGroup]="createVolumeForm" (ngSubmit)="createVolume(createVolumeForm.value)" [errorMessage]="errorMessage">
-    <form-item label="Name" [required]="true">
-        <input type="text" pInputText formControlName="name" />
-    </form-item>
-    <form-item label="Description">
-        <textarea pInputTextarea formControlName="description" [rows]="5" [cols]="25" autoResize="true"></textarea>
-    </form-item>
     <form-item label="Backend Type" [required]="true">
         <p-dropdown [style]="{'min-width':'150px','width':'220px'}" placeholder="Please select" [options]="allTypes" (onChange)="getBackendsByTypeId()" name='selectType' [(ngModel)]='selectType' formControlName="backend_type"></p-dropdown>
     </form-item>
     <form-item label="Backend" [required]="true">
         <p-dropdown [disabled]="!selectType" [style]="{'min-width':'150px','width':'220px'}" placeholder="Please select" [options]="backendsOption" (onChange)="setRegion()" formControlName="backendId"></p-dropdown>
+    </form-item>
+    <form-item label="Name" [required]="true">
+        <input type="text" pInputText formControlName="name" />
+    </form-item>
+    <form-item label="Description">
+        <textarea pInputTextarea formControlName="description" [rows]="5" [cols]="25" autoResize="true"></textarea>
     </form-item>
     <form-item label="Availability Zone" [required]="true">
         <input type="text" pInputText formControlName="availabilityZone" />
@@ -26,7 +26,7 @@
         <input type="text" pInputText formControlName="size" />
     </form-item>
     
-    <form-item *ngIf="selectedVolType=='io1'" label="IOPS" [required]="true">
+    <form-item *ngIf="createVolumeForm.controls['iops'] && selectedVolType=='io1'" label="IOPS" [required]="true">
         <input type="text" pInputText formControlName="iops" />
     </form-item>
     <form-item *ngIf="createVolumeForm.controls['encrypted']" label="Enable Encryption?" >

--- a/src/app/business/block/cloud-block-service/modify/cloud-volume-modify.component.html
+++ b/src/app/business/block/cloud-block-service/modify/cloud-volume-modify.component.html
@@ -4,16 +4,19 @@
 </div>
 
 <form *ngIf="modifyVolumeForm" [grid]="{label: 'ui-g-3', content:'ui-g-20'}" [formGroup]="modifyVolumeForm" (ngSubmit)="modifyVolume(modifyVolumeForm.value)" [errorMessage]="errorMessage">
-    <form-item label="Name" [required]="true">
+    <form-item *ngIf="!modifyVolumeForm.controls['name']" label="Name" [required]="true">
         <p>{{selectedVolume && selectedVolume.name}}</p>
     </form-item>
-    <form-item label="Description">
+    <form-item *ngIf="modifyVolumeForm.controls['name']" label="Name" [required]="true">
+        <input type="text" pInputText formControlName="name" />
+    </form-item>
+    <form-item *ngIf="modifyVolumeForm.controls['description']" label="Description">
         <textarea pInputTextarea formControlName="description" [rows]="5" [cols]="25" autoResize="true"></textarea>
     </form-item>
-    <form-item label="Volume Type" [required]="true">
+    <form-item *ngIf="modifyVolumeForm.controls['type']" label="Volume Type" [required]="true">
         <p-dropdown [style]="{'min-width':'150px','width':'220px'}" placeholder="Please select" [options]="volumeTypeOptions" (onChange)="onChangeVolType()" name='selectedVolType' [(ngModel)]='selectedVolType' formControlName="type"></p-dropdown>
     </form-item>
-    <form-item label="Size (GiB)" [required]="true">
+    <form-item *ngIf="modifyVolumeForm.controls['size']" label="Size (GiB)" [required]="true">
         <input type="text" pInputText formControlName="size" />
     </form-item>
     

--- a/src/app/shared/utils/consts.ts
+++ b/src/app/shared/utils/consts.ts
@@ -35,39 +35,42 @@ export const Consts = {
     BYTES_PER_CHUNK : 1024 * 1024 * 5,
     TIMEOUT: 30 * 60 * 1000,
 
-    CLOUD_TYPE:['aws-s3', 'aws-file', 'aws-block', 'azure-blob', 'azure-file','hw-obs','hw-file','fusionstorage-object','ceph-s3','ibm-cos','gcp-s3', 'gcp-file', 'yig', 'alibaba-oss'],
+    CLOUD_TYPE:['aws-s3', 'aws-file', 'aws-block', 'azure-blob', 'azure-file','hw-obs','hw-file', 'hw-block', 'fusionstorage-object','ceph-s3','ibm-cos','gcp-s3', 'gcp-file', 'yig', 'alibaba-oss'],
 
     TYPE_SVG:{
         "aws-s3":'aws.svg',
-        "hw-obs":"huawei.svg",
+        "aws-file" : 'aws.svg',
+        "aws-block" : 'aws.svg',
         "azure-blob":'azure.svg',
+        "azure-file" : 'azure.svg',
+        "hw-obs":"huawei.svg",
+        "hw-file" : 'huawei.svg',
+        "hw-block" : 'huawei.svg',
         "fusionstorage-object":"huawei.svg",
         "ceph-s3": "ceph.svg",
         "ibm-cos": "ibm.svg",
         "gcp-s3": "google.svg",
+        "gcp-file" : 'google.svg',
         "yig": "yig.png",
         'alibaba-oss': 'alibaba.svg',
-        "aws-file" : 'aws.svg',
-        "azure-file" : 'azure.svg',
-        "aws-block" : 'aws.svg',
-        "gcp-file" : 'google.svg',
-        "hw-file" : 'huawei.svg'
+        
     },
     CLOUD_TYPE_NAME: {
         'aws-s3': 'AWS S3',
+        'aws-file' : 'AWS File Storage',
+        'aws-block' : 'AWS Block Storage',
         'azure-blob': "Azure Blob Storage",
+        'azure-file' : 'Azure File Storage',
         'hw-obs': "Huawei OBS",
+        'hw-file' : 'Huawei File Storage',
+        'hw-block' : 'Huawei Block Storage',
         'fusionstorage-object': "FusionStorage Object",
         'ceph-s3': "Ceph S3",
         'gcp-s3': "GCP Object Storage",
+        'gcp-file' : 'GCP File Storage',
         'ibm-cos': "IBM COS",
         'yig': "YIG Ceph",
-        'alibaba-oss' : "Alibaba Object Storage",
-        'aws-file' : 'AWS File Storage',
-        'azure-file' : 'Azure File Storage',
-        'aws-block' : 'AWS Block Storage',
-        'gcp-file' : 'GCP File Storage',
-        'hw-file' : 'Huawei File Storage'
+        'alibaba-oss' : "Alibaba Object Storage"
     },
     S3_HOST_IP: '',
     S3_HOST_PORT: '',
@@ -78,5 +81,41 @@ export const Consts = {
             'storagePools' : 'resource-monitor/storage-pools',
             'volumes' : 'resource-monitor/volumes'
         }
-    }
+    },
+    AWS_VOLUME_TYPES: [
+        {
+            label: 'General Purpose',
+            value: 'gp2'
+        },
+        {
+            label: 'Provisioned IOPS',
+            value: 'io1'
+        },
+        {
+            label: 'Cold HDD',
+            value: 'sc1'
+        },
+        {
+            label: 'Throughput Optimized',
+            value: 'st1'
+        },
+        {
+            label: 'Magnetic(Standard)',
+            value: 'standard'
+        }
+    ],
+    HW_VOLUME_TYPES: [
+        {
+            label: 'SAS',
+            value: 'SAS'
+        },
+        {
+            label: 'GPSSD',
+            value: 'GPSSD'
+        },
+        {
+            label: 'SSD',
+            value: 'SSD'
+        }
+    ]
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What this PR does / why we need it**:
This PR adds support for Huawei EVS to SODA Dashboard.
User is now able to :

- [x] Create a Huawei EVS Volume
- [x] List a Huawei EVS Volume
- [x] Expand a Huawei EVS Volume to view details
- [x] Modify a Huawei EVS Volume
- [x] Delete a Huawei EVS Volume

**Which issue(s) this PR fixes**:

**## Depends on #443** 

Fixes #455 

**Test Report Added?**:
/kind TESTED


**Test Report**:
**Create a Huawei Volume**
![create-hw-vol-1](https://user-images.githubusercontent.com/19162717/96467073-2dc89f00-1248-11eb-9436-82b476f72def.png)
**Create a Huawei Volume Success**
![create-hw-vol-success](https://user-images.githubusercontent.com/19162717/96467068-2c977200-1248-11eb-9882-733c29fde340.png)
**Expand Huawei Volume**
![hw-vol-details](https://user-images.githubusercontent.com/19162717/96467055-2a351800-1248-11eb-8110-f27bb5c8b397.png)

**Modify Huawei Volume**
![modify-hw-vol](https://user-images.githubusercontent.com/19162717/96467049-2903eb00-1248-11eb-9bb4-b094833f8fc2.png)
**Modify success**
![modify-hw-vol-success](https://user-images.githubusercontent.com/19162717/96467043-27d2be00-1248-11eb-9bea-f9d89b7bdc06.png)

**Delete Huawei volume**
![delete-hw-vol](https://user-images.githubusercontent.com/19162717/96467036-26a19100-1248-11eb-85b1-0acd3bf03a0e.png)
![delete-hw-vol-success](https://user-images.githubusercontent.com/19162717/96467027-24d7cd80-1248-11eb-92ce-17dee5d84f83.png)




**Create AWS Volume**
![create-aws-vol-success](https://user-images.githubusercontent.com/19162717/96467059-2b664500-1248-11eb-9172-bc89871fb659.png)
![create-aws-vol-1](https://user-images.githubusercontent.com/19162717/96467062-2bfedb80-1248-11eb-8b93-7f301b1cdeb1.png)


**Special notes for your reviewer**:
