### PR TITLE
Added a configuration popup to enable performance collection for a storage device

### DIFF
--- a/src/app/business/delfin/delfin.module.ts
+++ b/src/app/business/delfin/delfin.module.ts
@@ -1,7 +1,7 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { CommonModule } from '@angular/common';
-import { ButtonModule, DataTableModule, PanelModule, OverlayPanelModule,  ChartModule, CardModule, TabViewModule, InputTextModule, DropMenuModule, DialogModule,FormModule,MultiSelectModule, GrowlModule ,DropdownModule,InputTextareaModule} from '../../components/common/api';
+import { ButtonModule, DataTableModule, PanelModule, OverlayPanelModule,  ChartModule, CardModule, TabViewModule, InputTextModule, InputSwitchModule, DropMenuModule, DialogModule,FormModule,MultiSelectModule, GrowlModule ,DropdownModule,InputTextareaModule} from '../../components/common/api';
 import { ScrollPanelModule } from '../../components/scrollpanel/scrollpanel';
 import { DataScrollerModule } from '../../components/datascroller/datascroller';
 import { TreeModule } from '../../components/tree/tree';
@@ -46,6 +46,7 @@ const routers: Routes = [{
     CardModule,
     TabViewModule,
     InputTextModule, 
+    InputSwitchModule,
     DropMenuModule, 
     DialogModule,
     FormModule,

--- a/src/app/business/delfin/delfin.service.ts
+++ b/src/app/business/delfin/delfin.service.ts
@@ -152,5 +152,10 @@ export class DelfinService {
     deleteAlerts(id, seqNum): Observable<any>{
         return this.http.delete(this.delfinStoragesUrl + '/' + id + '/alerts/' + seqNum);
     }
+
+    //Configure performance metrics collection
+    metricsConfig(id, params): Observable<any>{
+        return this.http.put(this.delfinStoragesUrl + '/' + id + '/metrics-config', params);
+    }
 }
 

--- a/src/app/business/delfin/storages/storages.component.html
+++ b/src/app/business/delfin/storages/storages.component.html
@@ -656,6 +656,37 @@
 
 </p-dialog>
 
+<p-dialog styleClass="perf-metrics-config-dialog"  header="Configure Performance Metrics Collection" [(visible)]="showperfMetricsConfigForm" [width]="700" modal="modal">
+    <form *ngIf="showperfMetricsConfigForm" [formGroup]="perfMetricsConfigForm" [grid]="{label: 'ui-g-5', content:'ui-g-7'}" [errorMessage]="errorMessage">
+       
+        <div class="ui-g">
+            <div class="ui-g-12">
+                <form-item label="{{perfMetricsConfigFormLabel.perf_collection}}" >
+                    <p-inputSwitch formControlName="perf_collection" onLabel="Yes" offLabel="No"></p-inputSwitch>
+                </form-item>
+            </div>
+        </div>
+        <div class="ui-g">
+            <div class="ui-g-12">
+                <form-item label="{{perfMetricsConfigFormLabel.interval}}">
+                    <input formControlName="interval" value="10" type="number" size="30" pInputText> 
+                </form-item>
+            </div>
+        </div>
+        <div class="ui-g">
+            <div class="ui-g-12">
+                <form-item label="{{perfMetricsConfigFormLabel.is_historic}}" >
+                    <p-inputSwitch formControlName="is_historic" onLabel="Yes" offLabel="No"></p-inputSwitch>
+                </form-item>
+            </div>
+        </div>
+    </form>
+    <p-footer>
+        <button type="submit" class="ui-button-secondary" pButton [disabled]="perfMetricsConfigForm.invalid" (click)="configurePerformanceMetrics(perfMetricsConfigForm.value)"  label="{{i18n.keyID['ok']}}"></button>
+        <button type="button" pButton (click)="closePerfConfigDialog()"  label="{{i18n.keyID['cancel']}}"></button>
+    </p-footer>
+
+</p-dialog>
 <p-overlayPanel styleClass="overview-panel" #deviceOverviewPanel>
     <div class="ui-g overview-title">
         <h4>{{storageOverview && storageOverview.name}}</h4>

--- a/src/app/business/delfin/storages/storages.component.ts
+++ b/src/app/business/delfin/storages/storages.component.ts
@@ -43,6 +43,8 @@ export class StoragesComponent implements OnInit {
     selectedAuthProtocol: any;
     privacyProtocolOptions: any;
     selectedPrivacyProtocol: any;
+    perfMetricsConfigForm: any;
+    showperfMetricsConfigForm: boolean = false;
     registerAlertSourceForm: any;
     showRegisterAlertSourceForm: boolean = false;
     v2cFields: boolean = false;
@@ -92,6 +94,12 @@ export class StoragesComponent implements OnInit {
         sync_status : "Sync Status"
 
     };
+
+    perfMetricsConfigFormLabel = {
+        "perf_collection": "Enable Performance collection?",
+        "interval" : "Scrape Interval",
+        "is_historic": "Enable History?"
+    }
 
     alertSourceFormlabel = {
         "version": "Version",
@@ -198,6 +206,14 @@ export class StoragesComponent implements OnInit {
                 "label": "Sync Storage Device",
                 command: () => {
                     this.syncStorage(this.selectStorage.id);
+                },
+                disabled:false
+            },
+            {
+                "label": "Configure Metric Collection",
+
+                command: () => {
+                    this.showPerfConfigDialog(this.selectStorage);
                 },
                 disabled:false
             },
@@ -327,6 +343,11 @@ export class StoragesComponent implements OnInit {
         ];
 
         this.registerAlertSourceForm = this.fb.group({});
+        this.perfMetricsConfigForm = this.fb.group({
+            'perf_collection': new FormControl(true, Validators.required),
+            'interval': new FormControl(10, Validators.required),
+            "is_historic": new FormControl(true, Validators.required)            
+        });
            
     }
     updateAccessInfo(storage){
@@ -736,6 +757,14 @@ export class StoragesComponent implements OnInit {
                     disabled:false
                 },
                 {
+                    "label": "Configure Metric Collection",
+    
+                    command: () => {
+                        this.showPerfConfigDialog(node['details']);
+                    },
+                    disabled:false
+                },
+                {
                     "label": this.i18n.keyID['sds_block_volume_delete'],
                     command: () => {
                         this.batchDeleteStorages(node['details']);
@@ -925,6 +954,56 @@ export class StoragesComponent implements OnInit {
             })
         }
         
+    }
+    
+    showPerfConfigDialog(storage){
+        this.selectedStorageId = storage['id'];
+        this.showperfMetricsConfigForm = true;
+    }
+
+    closePerfConfigDialog(){
+        this.showperfMetricsConfigForm = false;
+        this.perfMetricsConfigForm.reset({
+            'perf_collection': true,
+            'interval': 10,
+            'is_historic': true
+        });
+    }
+
+    configurePerformanceMetrics(value){
+        if(!this.perfMetricsConfigForm.valid){
+            for(let i in this.perfMetricsConfigForm.controls){
+                this.perfMetricsConfigForm.controls[i].markAsTouched();
+            }
+            return;
+        }
+        let perfParam = {
+            "array_polling":{
+                "perf_collection" : value['perf_collection'],
+                "interval": value['interval'],
+                "is_historic": value['is_historic']
+            }
+        }
+
+        this.ds.metricsConfig(this.selectedStorageId, perfParam).subscribe((res)=>{
+            this.showperfMetricsConfigForm=false;
+            this.msgs = [];
+            this.msgs.push({severity: 'success', summary: 'Success', detail: 'Performance metrics collection configured successfully.'});
+            this.perfMetricsConfigForm.reset({
+                'perf_collection': true,
+                'interval': 10,
+                'is_historic': true
+            });
+        }, (error) =>{
+            this.msgs = [];
+            this.msgs.push({severity: 'error', summary: "Error", detail:"Something went wrong. Performance metrics collection could not be configured."});
+            console.log("Something went wrong. Performance metrics collection could not be configured.", error);
+            this.perfMetricsConfigForm.reset({
+                'perf_collection': true,
+                'interval': 10,
+                'is_historic': true
+            });
+        })
     }
 
     showAlertSourceDialog(storage){

--- a/src/app/business/delfin/storages/storages.component.ts
+++ b/src/app/business/delfin/storages/storages.component.ts
@@ -97,8 +97,8 @@ export class StoragesComponent implements OnInit {
 
     perfMetricsConfigFormLabel = {
         "perf_collection": "Enable Performance collection?",
-        "interval" : "Scrape Interval",
-        "is_historic": "Enable History?"
+        "interval" : "Polling Interval (seconds)",
+        "is_historic": "Enable Historic metric collection?"
     }
 
     alertSourceFormlabel = {


### PR DESCRIPTION
**What type of PR is this?**
/kind new feature

**What this PR does / why we need it**:
This PR enables the user to configure the performance metrics collection settings for a storage device.
The user will be able to : 
- Enable performance collection
- Set the scrape interval
- Enable history

**Which issue(s) this PR fixes**:
Fixes #404 

**Test Report Added?**:
 /kind TESTED


**Test Report**:
![config-perf-collection-context-menu](https://user-images.githubusercontent.com/19162717/100515911-ca665100-31a5-11eb-9284-4387e48b5c0d.png)
![config-perf-collection-menu](https://user-images.githubusercontent.com/19162717/100515912-cdf9d800-31a5-11eb-94d0-81ca3739af38.png)
![config-perf-collection-popup](https://user-images.githubusercontent.com/19162717/100515913-cfc39b80-31a5-11eb-8c94-c2fcec452a96.png)
![config-perf-collection-success](https://user-images.githubusercontent.com/19162717/100515921-e2d66b80-31a5-11eb-832d-dccb19d52b8a.png)


**Special notes for your reviewer**:
