### PR TITLE
Fixed #470. Changed 'Create Host' to 'Register Host'

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -12,7 +12,7 @@ const routes: Routes = [
     {path: 'createCloudVolume', loadChildren: './business/block/cloud-block-service/create/cloud-volume-create.module#CloudVolumeCreateModule'},
     {path: 'modifyCloudVolume/:volumeId', loadChildren: './business/block/cloud-block-service/modify/cloud-volume-modify.module#CloudVolumeModifyModule'},
     {path: 'volumeDetails/:volumeId', loadChildren: './business/block/volume-detail/volume-detail.module#VolumeDetailModule'},
-    {path: 'createHost', loadChildren: './business/block/create-host/create-host.module#CreateHostModule'},
+    {path: 'registerHost', loadChildren: './business/block/create-host/create-host.module#CreateHostModule'},
     {path: 'modifyHost/:hostId', loadChildren: './business/block/modify-host/modify-host.module#ModifyHostModule',
         resolve: {
             host: HostsResolver,

--- a/src/app/business/block/create-host/create-host.component.html
+++ b/src/app/business/block/create-host/create-host.component.html
@@ -8,7 +8,7 @@
             </span>
         </div>
         <div class="content-header">
-            <h1>{{i18n.keyID['sds_create_host']}}</h1>
+            <h1>{{i18n.keyID['sds_register_host']}}</h1>
             <p>{{i18n.keyID['sds_block_createHost_desc']}}</p>
         </div>
         <hr />

--- a/src/app/business/block/create-host/create-host.component.ts
+++ b/src/app/business/block/create-host/create-host.component.ts
@@ -124,7 +124,7 @@ export class CreateHostComponent implements OnInit {
     this.getAZ();
     this.items = [
         { label: this.i18n.keyID["sds_Hosts_title"], url: '/block' },
-        { label: this.i18n.keyID["sds_create_host"], url: '/createHost' }
+        { label: this.i18n.keyID["sds_create_host"], url: '/registerHost' }
     ];
     this.createHostform = this.fb.group({
         'availabilityZones': new FormControl('', Validators.required),

--- a/src/app/business/block/hosts.component.html
+++ b/src/app/business/block/hosts.component.html
@@ -1,7 +1,7 @@
 <p-growl [value]="msgs" [sticky]="false" [life]="6000"></p-growl>
 <div class="table-toolbar">
     <div class="left">
-        <button class="ui-button-secondary" pButton type="button" label="{{I18N.keyID['sds_block_volume_create']}}" [routerLink]="['/createHost']"></button>
+        <button class="ui-button-secondary" pButton type="button" label="{{I18N.keyID['sds_common_register']}}" [routerLink]="['/registerHost']"></button>
         <button pButton type="button" label="{{I18N.keyID['sds_block_volume_delete']}}" [disabled]="selectedHosts.length == 0" (click)="batchDeleteHosts(selectedHosts)"></button></div>
     <div class="right">
         <div class="ui-inputsearch">

--- a/src/app/business/block/volumeList.html
+++ b/src/app/business/block/volumeList.html
@@ -116,8 +116,8 @@
             <p-dropdown [disabled]="noHosts" [options]="hostOptions" formControlName="hostId" placeholder="Please select"></p-dropdown>
             <div *ngIf="noHosts">
                 <i class="fa fa-exclamation-circle fa-2x"></i>
-                <span >There are no hosts. Would you like to add one? </span>
-                <a  [routerLink]="['/createHost']">Add Host</a>
+                <span >There are no hosts. Would you like to register one? </span>
+                <a  [routerLink]="['/registerHost']">{{I18N.keyID['sds_register_host']}}</a>
             </div>
             
         </form-item>

--- a/src/app/business/services/dynamic-form/dynamic-form.component.html
+++ b/src/app/business/services/dynamic-form/dynamic-form.component.html
@@ -56,8 +56,8 @@
                     <p-dropdown [disabled]="noHosts && (prop.key == 'host_id')" [options]="prop.options" [required]="true" [formControlName]="prop.key" [placeholder]="prop.description ? prop.description : ''"></p-dropdown>
                     <div class="input-context-help" *ngIf="(prop.key == 'host_id')">
                         <i class="fa fa-exclamation-circle fa-2x"></i>
-                        <span *ngIf="noHosts">There are no hosts.</span><span >Would you like to add a host? </span>
-                        <a  [routerLink]="['/createHost']">Add Host</a>
+                        <span *ngIf="noHosts">There are no hosts.</span><span >Would you like to register a host? </span>
+                        <a  [routerLink]="['/registerHost']">Register Host</a>
                     </div>
                 </form-item>      
             </div>

--- a/src/app/i18n/en/keyID.json
+++ b/src/app/i18n/en/keyID.json
@@ -4,6 +4,8 @@
     "sds_common_delete" : "Delete",
     "sds_common_search" : "Search",
     "sds_common_profile" : "Profile",
+    "sds_common_register" : "Register",
+    "sds_common_discover" : "Discover",
     "sds_required":"{0} is required.",
     "sds_pattern":"Beginning with a letter with a length of 1-128, it can contain letters / numbers / underlines.",
     "sds_profileNull":"profile is required",
@@ -165,7 +167,7 @@
     "sds_block_attach_mode" : "Attach Mode",
     "sds_Hosts_title": "Hosts",
     "sds_Host_detail": "Host details",
-    "sds_create_host": "Create Host",
+    "sds_register_host": "Register Host",
     "sds_host_os_type": "OS Type",
     "sds_host_ip": "IP Address",
     "sds_host_access_mode": "Access Mode",
@@ -173,6 +175,7 @@
     "sds_host_availability_zones": "Availability Zones",
     "sds_block_createHost_desc" : "Add a new host",
     "sds_block_host_delete":"Delete Host",
+    "sds_modify_host" : "Modify Host",
     "sds_cloud_file_share_create": "Create",
     "sds_cloud_file_share_delete": "Delete"
 }

--- a/src/app/i18n/zh/keyID.json
+++ b/src/app/i18n/zh/keyID.json
@@ -4,6 +4,8 @@
     "sds_common_delete" : "Delete",
     "sds_common_search" : "Search",
     "sds_common_profile" : "Profile",
+    "sds_common_register" : "Register",
+    "sds_common_discover" : "Discover",
     "sds_required":"{0} is required.",
     "sds_pattern":"Beginning with a letter with a length of 1-128, it can contain letters / numbers / underlines.",
     "sds_profileNull":"profile is required",
@@ -165,7 +167,7 @@
     "sds_block_attach_mode" : "Attach Mode",
     "sds_Hosts_title": "Hosts",
     "sds_Host_detail": "Host details",
-    "sds_create_host": "Create Host",
+    "sds_register_host": "Register Host",
     "sds_host_os_type": "OS Type",
     "sds_host_ip": "IP Address",
     "sds_host_access_mode": "Access Mode",
@@ -173,6 +175,7 @@
     "sds_host_availability_zones": "Availability Zones",
     "sds_block_createHost_desc" : "Add a new host",
     "sds_block_host_delete":"Delete Host",
+    "sds_modify_host" : "Modify Host",
     "sds_cloud_file_share_create": "Create",
     "sds_cloud_file_share_delete": "Delete"
 }


### PR DESCRIPTION
**What type of PR is this?**
 /kind enhancement

**What this PR does / why we need it**:
This PR changes the 'Create Host' nomenclature to 'Register Host'.
Under the host management section the user can register a new host by providing the necessary connection information. 
Creating a new host would involve the infrastructure provisioning, which we do not do. 
Hence the language is now changed to 'Register Host' as we are registering an already created host. 
The issue suggested we make it "Discover Host" but this change is going with the nomenclature we have used in Delfin for storage (Register Storage).
The associated changes have been made in Volume list and Orchestration create instance.

**Which issue(s) this PR fixes**:
Fixes #470 

**Test Report Added?**:
 /kind TESTED


**Test Report**:
![register-host-button](https://user-images.githubusercontent.com/19162717/100538527-5768e300-3256-11eb-9215-a54ca730da57.png)
![register-host-page](https://user-images.githubusercontent.com/19162717/100538529-5a63d380-3256-11eb-9bb5-b7714072a011.png)
![register-host-volume-list](https://user-images.githubusercontent.com/19162717/100538532-5cc62d80-3256-11eb-95d6-d3cd5f26afe1.png)

**Special notes for your reviewer**:
