### PR TITLE
Added support to register Hitachi VSP and IBM Storwize/SVC storage devices from dashboard

### DIFF
--- a/src/app/business/delfin/modify-storage/modify-storage.component.ts
+++ b/src/app/business/delfin/modify-storage/modify-storage.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ViewContainerRef, ViewChild, Directive, ElementRef, HostBinding, HostListener } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
-import { I18NService, Utils } from 'app/shared/api';
+import { I18NService, Utils, Consts } from 'app/shared/api';
 import { FormControl, FormGroup, FormArray, FormBuilder, Validators, ValidatorFn, AbstractControl } from '@angular/forms';
 import { AppService } from 'app/app.service';
 import { I18nPluralPipe } from '@angular/common';
@@ -122,82 +122,11 @@ export class ModifyStorageComponent implements OnInit {
             },
 
         ];
-        this.vendorOptions = [
-            {
-                label: "Dell EMC",
-                value: 'dellemc'
-            },
-            {
-              label: "Huawei",
-              value: 'huawei'
-            },
-            {
-                label: "HPE",
-                value: 'hpe'
-            }
-        ];
+        this.vendorOptions = Consts.STORAGES.vendors;
 
-        this.allStorageModels = {
-            'dellemc' : [
-                {
-                    label: "VMAX",
-                    value: {
-                        name: 'vmax',
-                        rest: true,
-                        ssh: false,
-                        extra: true
-                    }
-                }
-            ],
-            'huawei' : [
-                {
-                    label: "OceanStor V3",
-                    value: {
-                        name: 'oceanstor',
-                        rest: true,
-                        ssh: false,
-                        extra: false
-                    }
-                }
-            ],
-            'hpe' : [
-                {
-                    label: "3PAR",
-                    value: {
-                        name: '3par',
-                        rest: true,
-                        ssh: true,
-                        extra: false
-                    }
-                }
-            ]
-        };
-        this.pubKeyTypeOptions = [
-            {
-                label: "ssh-ed25519",
-                value: "ssh-ed25519"
-            },
-            {
-                label: "ecdsa-sha2-nistp256",
-                value: "ecdsa-sha2-nistp256"
-            },
-            {
-                label: "ecdsa-sha2-nistp384",
-                value: "ecdsa-sha2-nistp384"
-            },
-            {
-                label: "ecdsa-sha2-nistp521",
-                value: "ecdsa-sha2-nistp521"
-            },
-            {
-                label: "ssh-rsa",
-                value: "ssh-rsa"
-            },
-            {
-                label: "ssh-dss",
-                value: "ssh-dss"
-            }
-        ];
+        this.allStorageModels = Consts.STORAGES.models;
+
+        this.pubKeyTypeOptions = Consts.STORAGES.pubKeyTypeOptions;
 
         this.ds.getStorageById(this.selectedStorageId).subscribe((res)=>{
             let storageDevice;

--- a/src/app/business/delfin/modify-storage/modify-storage.component.ts
+++ b/src/app/business/delfin/modify-storage/modify-storage.component.ts
@@ -122,10 +122,11 @@ export class ModifyStorageComponent implements OnInit {
             },
 
         ];
+        //All Supported vendors
         this.vendorOptions = Consts.STORAGES.vendors;
-
+        //All Supported models
         this.allStorageModels = Consts.STORAGES.models;
-
+        //All Supported pubkey type options
         this.pubKeyTypeOptions = Consts.STORAGES.pubKeyTypeOptions;
 
         this.ds.getStorageById(this.selectedStorageId).subscribe((res)=>{

--- a/src/app/business/delfin/register-storage/register-storage.component.ts
+++ b/src/app/business/delfin/register-storage/register-storage.component.ts
@@ -115,10 +115,15 @@ export class RegisterStorageComponent implements OnInit {
                 url: '/registerStorage' 
             }
         ];
+                       
+        //All Supported storage vendors
         this.vendorOptions = Consts.STORAGES.vendors;
-
+        
+        //All supported storage models based on vendors
         this.allStorageModels = Consts.STORAGES.models;
-
+        
+        //All supported public key type options
+        //["ssh-ed25519", "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp521", "ssh-rsa", "ssh-dss"]
         this.pubKeyTypeOptions = Consts.STORAGES.pubKeyTypeOptions;
 
         this.registerStorageForm = this.fb.group({

--- a/src/app/business/delfin/register-storage/register-storage.component.ts
+++ b/src/app/business/delfin/register-storage/register-storage.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ViewContainerRef, ViewChild, Directive, ElementRef, HostBinding, HostListener } from '@angular/core';
 import { Router } from '@angular/router';
-import { I18NService, Utils } from 'app/shared/api';
+import { Consts, I18NService, Utils } from 'app/shared/api';
 import { FormControl, FormGroup, FormArray, FormBuilder, Validators, ValidatorFn, AbstractControl } from '@angular/forms';
 import { AppService } from 'app/app.service';
 import { I18nPluralPipe } from '@angular/common';
@@ -115,83 +115,11 @@ export class RegisterStorageComponent implements OnInit {
                 url: '/registerStorage' 
             }
         ];
-        this.vendorOptions = [
-            {
-                label: "Dell EMC",
-                value: 'dellemc'
-            },
-            {
-              label: "Huawei",
-              value: 'huawei'
-            },
-            {
-                label: "HPE",
-                value: 'hpe'
-            }
-        ];
+        this.vendorOptions = Consts.STORAGES.vendors;
 
-        this.allStorageModels = {
-            'dellemc' : [
-                {
-                    label: "VMAX",
-                    value: {
-                        name: 'vmax',
-                        rest: true,
-                        ssh: false,
-                        extra: true
-                    }
-                }
-            ],
-            'huawei' : [
-                {
-                    label: "OceanStor V3",
-                    value: {
-                        name: 'oceanstor',
-                        rest: true,
-                        ssh: false,
-                        extra: false
-                    }
-                }
-            ],
-            'hpe' : [
-                {
-                    label: "3PAR",
-                    value: {
-                        name: '3par',
-                        rest: true,
-                        ssh: true,
-                        extra: false
-                    }
-                }
-            ]
-        };
+        this.allStorageModels = Consts.STORAGES.models;
 
-        this.pubKeyTypeOptions = [
-            {
-                label: "ssh-ed25519",
-                value: "ssh-ed25519"
-            },
-            {
-                label: "ecdsa-sha2-nistp256",
-                value: "ecdsa-sha2-nistp256"
-            },
-            {
-                label: "ecdsa-sha2-nistp384",
-                value: "ecdsa-sha2-nistp384"
-            },
-            {
-                label: "ecdsa-sha2-nistp521",
-                value: "ecdsa-sha2-nistp521"
-            },
-            {
-                label: "ssh-rsa",
-                value: "ssh-rsa"
-            },
-            {
-                label: "ssh-dss",
-                value: "ssh-dss"
-            }
-        ]
+        this.pubKeyTypeOptions = Consts.STORAGES.pubKeyTypeOptions;
 
         this.registerStorageForm = this.fb.group({
             'vendor': new FormControl('', Validators.required),

--- a/src/app/business/delfin/storage-details/storage-details.component.ts
+++ b/src/app/business/delfin/storage-details/storage-details.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ViewContainerRef, ViewChild, Directive, ElementRef, HostBinding, HostListener } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
-import { I18NService, Utils } from 'app/shared/api';
+import { I18NService, Utils, Consts} from 'app/shared/api';
 import { FormControl, FormGroup, FormBuilder, Validators, ValidatorFn, AbstractControl } from '@angular/forms';
 import { AppService } from 'app/app.service';
 import { I18nPluralPipe } from '@angular/common';
@@ -441,111 +441,6 @@ export class StorageDetailsComponent implements OnInit {
             let errorMsg = 'Error fetching alerts.' + error.error_msg;
             this.msgs.push({severity: 'error', summary: 'Error', detail: error});
         })
-        // FIXME ALERTS DUMMY DATA
-        /* this.allActiveAlerts.push(
-            {
-                'alert_id' : '255911',
-                'alert_name' : 'TP VV allocation failure',
-                'severity' : 'Critical',
-                'category' : 'Fault',
-                'type' : 'EquipmentAlarm',
-                'sequence_number' : 657,
-                'occur_time' : 1514140673000,
-                'description' : 'Thin provisioned VV LUN_performance_test.531 unable to allocate SD space from CPG cpg_zhu',
-                'resource_type' : 'Storage',
-                'location' : 'sw_vv:20656:LUN_performance_test.899',
-                'storage_id' : '4ec28b27-0d3d-4876-8da7-a16876ea489c',
-                'storage_name' : 'HPEDevice',
-                'vendor' : 'HPE',
-                'model' : 'HP_3PAR 8450',
-                'serial_number' : 'XXYYZZ1234'
-            },
-            {
-                'alert_id' : '255912',
-                'alert_name' : 'Storage Array Usable Free Space is less than 20%',
-                'severity' : 'Critical',
-                'category' : 'Fault',
-                'type' : 'EquipmentAlarm',
-                'sequence_number' : 658,
-                'occur_time' : 1514140673010,
-                'description' : 'Storage Array Usable Free Space is less than 20% was triggered.',
-                'resource_type' : 'Storage',
-                'location' : 'sw_vv:20656:LUN_performance_test.900',
-                'storage_id' : '4ec28b27-0d3d-4876-8da7-a16876ea479c',
-                'storage_name' : 'DellVMAX250F',
-                'vendor' : 'Dell EMC',
-                'model' : 'VMAX250F',
-                'serial_number' : 'XXYY5678'
-            },
-            {
-                'alert_id' : '255915',
-                'alert_name' : 'Pool Usable Free Space is less than 20%',
-                'severity' : 'Warning',
-                'category' : 'Fault',
-                'type' : 'EquipmentAlarm',
-                'sequence_number' : 659,
-                'occur_time' : 1514140674050,
-                'description' : 'Pool Usable Free Space is less than 20% was triggered.',
-                'resource_type' : 'Storage',
-                'location' : 'sw_vv:20656:LUN_performance_test.900',
-                'storage_id' : '4ec28b27-0d3d-4876-8da7-a16876ea479c',
-                'storage_name' : 'OceanStorV3',
-                'vendor' : 'Huawei',
-                'model' : 'OceanStor V3',
-                'serial_number' : 'XXYY9101'
-            },
-            {
-                'alert_id' : '255811',
-                'alert_name' : 'TP VV allocation failure',
-                'severity' : 'Critical',
-                'category' : 'Fault',
-                'type' : 'EquipmentAlarm',
-                'sequence_number' : 657,
-                'occur_time' : 1514140673000,
-                'description' : 'Thin provisioned VV LUN_performance_test.531 unable to allocate SD space from CPG cpg_zhu',
-                'resource_type' : 'Storage',
-                'location' : 'sw_vv:20656:LUN_performance_test.899',
-                'storage_id' : '4ec28b27-0d3d-4876-8da7-a16876ea489c',
-                'storage_name' : 'HPEDevice',
-                'vendor' : 'HPE',
-                'model' : 'HP_3PAR 8450',
-                'serial_number' : 'XXYYZZ1234'
-            },
-            {
-                'alert_id' : '255812',
-                'alert_name' : 'Storage Array Usable Free Space is less than 20%',
-                'severity' : 'Critical',
-                'category' : 'Fault',
-                'type' : 'EquipmentAlarm',
-                'sequence_number' : 658,
-                'occur_time' : 1514140673010,
-                'description' : 'Storage Array Usable Free Space is less than 20% was triggered.',
-                'resource_type' : 'Storage',
-                'location' : 'sw_vv:20656:LUN_performance_test.900',
-                'storage_id' : '4ec28b27-0d3d-4876-8da7-a16876ea479c',
-                'storage_name' : 'DellVMAX250F',
-                'vendor' : 'Dell EMC',
-                'model' : 'VMAX250F',
-                'serial_number' : 'XXYY5678'
-            },
-            {
-                'alert_id' : '255815',
-                'alert_name' : 'Pool Usable Free Space is less than 20%',
-                'severity' : 'Warning',
-                'category' : 'Fault',
-                'type' : 'EquipmentAlarm',
-                'sequence_number' : 659,
-                'occur_time' : 1514140674050,
-                'description' : 'Pool Usable Free Space is less than 20% was triggered.',
-                'resource_type' : 'Storage',
-                'location' : 'sw_vv:20656:LUN_performance_test.900',
-                'storage_id' : '4ec28b27-0d3d-4876-8da7-a16876ea479c',
-                'storage_name' : 'OceanStorV3',
-                'vendor' : 'Huawei',
-                'model' : 'OceanStor V3',
-                'serial_number' : 'XXYY9101'
-            }
-        ); */
-        // FIXME ALERTS DUMMY DATA
+        
     }
 }

--- a/src/app/business/delfin/storages/storages.component.ts
+++ b/src/app/business/delfin/storages/storages.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ViewContainerRef, ViewChild, Directive, ElementRef, HostBinding, HostListener } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
-import { I18NService, Utils } from 'app/shared/api';
+import { Consts, I18NService, Utils } from 'app/shared/api';
 import { FormControl, FormGroup, FormBuilder, Validators, ValidatorFn, AbstractControl } from '@angular/forms';
 import { AppService } from 'app/app.service';
 import { I18nPluralPipe } from '@angular/common';
@@ -223,108 +223,26 @@ export class StoragesComponent implements OnInit {
                 value: 'hpe'
             }
         ];
+        //All Supported storage vendors
+        this.vendorOptions = Consts.STORAGES.vendors;
 
-        this.allStorageModels = {
-            'dellemc' : [
-                {
-                    label: "VMAX",
-                    value: 'vmax'
-                }
-            ],
-            'huawei' : [
-                {
-                    label: "OceanStor",
-                    value: 'oceanstor'
-                }
-            ],
-            'hpe' : [
-                {
-                    label: "3PAR",
-                    value: '3par'
-                }
-            ]
-        };
-        this.versionOptions = [
-            {
-                label: "SNMPV2C",
-                value: 'SNMPv2c'
-            },
-            {
-              label: "SNMPV3",
-              value: 'SNMPv3'
-            }
-        ];
+        //All supported storage models based on vendors
+        this.allStorageModels = Consts.STORAGES.models;
+
+        // Alert Source Version options
+        this.versionOptions = Consts.STORAGES.alertSourceVersionOptions;
+
         // Supported security levels
         // ['authPriv', 'authNoPriv', 'noAuthnoPriv']
-        this.securityLeveloptions = [
-            {
-                label: "noAuthnoPriv",
-                value: "noAuthnoPriv"
-            },
-            {
-                label: "authNoPriv",
-                value: "authNoPriv"
-            },
-            {
-                label: "authPriv",
-                value: "authPriv"
-            }
-        ];
+        this.securityLeveloptions = Consts.STORAGES.securityLevelOptions;
+
         // Supported Auth Protocols
         //['HMACSHA', 'HMACMD5', 'HMCSHA2224', 'HMCSHA2256', 'HMCSHA2384', 'HMCSHA2512']
-        this.authProtocolOptions = [
-            {
-                label: "HMACSHA",
-                value: "HMACSHA"
-            },
-            {
-                label: "HMACMD5",
-                value: "HMACMD5"
-            },
-            {
-                label: "HMCSHA2224",
-                value: "HMCSHA2224"
-            },
-            {
-                label: "HMCSHA2256",
-                value: "HMCSHA2256"
-            },
-            {
-                label: "HMCSHA2384",
-                value: "HMCSHA2384"
-            },
-            {
-                label: "HMCSHA2512",
-                value: "HMCSHA2512"
-            }
+        this.authProtocolOptions = Consts.STORAGES.authProtocolOptions;
         
-        ];
         //Supported Types
         //['DES', 'AES', 'AES192', 'AES256', '3DES']
-        this.privacyProtocolOptions = [
-            {
-                label: "DES",
-                value: "DES"
-            },
-            {
-                label: "AES",
-                value: "AES"
-            },
-            {
-                label: "AES192",
-                value: "AES192"
-            },
-            {
-                label: "AES256",
-                value: "AES256"
-            },
-            {
-                label: "3DES",
-                value: "3DES"
-            },
-            
-            
-        ];
+        this.privacyProtocolOptions = Consts.STORAGES.privacyProtocolOptions;
 
         this.registerAlertSourceForm = this.fb.group({});
            

--- a/src/app/shared/utils/consts.ts
+++ b/src/app/shared/utils/consts.ts
@@ -139,10 +139,6 @@ export const Consts = {
             {
                 label: "IBM",
                 value: 'ibm'
-            },
-            {
-                label: "Demo Storage",
-                value: 'fake_storage'
             }
         ],
         models: {
@@ -198,17 +194,6 @@ export const Consts = {
                         rest: false,
                         ssh: true,
                         extra: false
-                    }
-                }
-            ],
-            'fake_storage' : [
-                {
-                    label: "Demo Driver",
-                    value: {
-                        name: 'fake_driver',
-                        rest: true,
-                        ssh: true,
-                        extra: true
                     }
                 }
             ]

--- a/src/app/shared/utils/consts.ts
+++ b/src/app/shared/utils/consts.ts
@@ -117,5 +117,202 @@ export const Consts = {
             label: 'SSD',
             value: 'SSD'
         }
-    ]
+    ],
+    STORAGES: {
+        vendors: [
+            {
+                label: "Dell EMC",
+                value: 'dellemc'
+            },
+            {
+                label: "Huawei",
+                value: 'huawei'
+            },
+            {
+                label: "HPE",
+                value: 'hpe'
+            },
+            {
+                label: "Hitachi",
+                value: 'hitachi'
+            },
+            {
+                label: "IBM",
+                value: 'ibm'
+            },
+            {
+                label: "Demo Storage",
+                value: 'fake_storage'
+            }
+        ],
+        models: {
+            'dellemc' : [
+                {
+                    label: "VMAX",
+                    value: {
+                        name: 'vmax',
+                        rest: true,
+                        ssh: false,
+                        extra: true
+                    }
+                }
+            ],
+            'huawei' : [
+                {
+                    label: "OceanStor V3",
+                    value: {
+                        name: 'oceanstor',
+                        rest: true,
+                        ssh: false,
+                        extra: false
+                    }
+                }
+            ],
+            'hpe' : [
+                {
+                    label: "3PAR",
+                    value: {
+                        name: '3par',
+                        rest: true,
+                        ssh: true,
+                        extra: false
+                    }
+                }
+            ],
+            'hitachi' : [
+                {
+                    label: "VSP",
+                    value: {
+                        name: 'vsp',
+                        rest: true,
+                        ssh: false,
+                        extra: false
+                    }
+                }
+            ],
+            'ibm' : [
+                {
+                    label: "Storwize / SVC",
+                    value: {
+                        name: 'storwize_svc',
+                        rest: false,
+                        ssh: true,
+                        extra: false
+                    }
+                }
+            ],
+            'fake_storage' : [
+                {
+                    label: "Demo Driver",
+                    value: {
+                        name: 'fake_driver',
+                        rest: true,
+                        ssh: true,
+                        extra: true
+                    }
+                }
+            ]
+        },
+        pubKeyTypeOptions: [
+            {
+                label: "ssh-ed25519",
+                value: "ssh-ed25519"
+            },
+            {
+                label: "ecdsa-sha2-nistp256",
+                value: "ecdsa-sha2-nistp256"
+            },
+            {
+                label: "ecdsa-sha2-nistp384",
+                value: "ecdsa-sha2-nistp384"
+            },
+            {
+                label: "ecdsa-sha2-nistp521",
+                value: "ecdsa-sha2-nistp521"
+            },
+            {
+                label: "ssh-rsa",
+                value: "ssh-rsa"
+            },
+            {
+                label: "ssh-dss",
+                value: "ssh-dss"
+            }
+        ],
+        alertSourceVersionOptions: [
+            {
+                label: "SNMPV2C",
+                value: 'SNMPv2c'
+            },
+            {
+              label: "SNMPV3",
+              value: 'SNMPv3'
+            }
+        ],
+        securityLevelOptions: [
+            {
+                label: "noAuthnoPriv",
+                value: "noAuthnoPriv"
+            },
+            {
+                label: "authNoPriv",
+                value: "authNoPriv"
+            },
+            {
+                label: "authPriv",
+                value: "authPriv"
+            }
+        ],
+        authProtocolOptions: [
+            {
+                label: "HMACSHA",
+                value: "HMACSHA"
+            },
+            {
+                label: "HMACMD5",
+                value: "HMACMD5"
+            },
+            {
+                label: "HMCSHA2224",
+                value: "HMCSHA2224"
+            },
+            {
+                label: "HMCSHA2256",
+                value: "HMCSHA2256"
+            },
+            {
+                label: "HMCSHA2384",
+                value: "HMCSHA2384"
+            },
+            {
+                label: "HMCSHA2512",
+                value: "HMCSHA2512"
+            }
+        
+        ],
+        privacyProtocolOptions: [
+            {
+                label: "DES",
+                value: "DES"
+            },
+            {
+                label: "AES",
+                value: "AES"
+            },
+            {
+                label: "AES192",
+                value: "AES192"
+            },
+            {
+                label: "AES256",
+                value: "AES256"
+            },
+            {
+                label: "3DES",
+                value: "3DES"
+            },
+            
+            
+        ]
+    },
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What this PR does / why we need it**:
This PR adds the support to register Hitachi VSP and IBM Storwize / SVC devices from the dashboard.
This PR also fixes some optimisation issues of constants and removed commented code.

**Which issue(s) this PR fixes**:
Fixes #475 #477 

**Test Report Added?**:
/kind TESTED


**Test Report**:
![new-storage-1](https://user-images.githubusercontent.com/19162717/101392252-854fc680-38eb-11eb-907c-3d159c6a9534.png)
![new-storage-2-ibm](https://user-images.githubusercontent.com/19162717/101392251-84b73000-38eb-11eb-8e49-ac1fd276e381.png)
![new-storage-3-hitachi](https://user-images.githubusercontent.com/19162717/101392243-82ed6c80-38eb-11eb-9721-29cf5c7b5b39.png)


**Special notes for your reviewer**:
