### PR TITLE
Fixed configure metrics link appearing twice in operations menu in list storages

### DIFF
--- a/src/app/business/delfin/storages/storages.component.ts
+++ b/src/app/business/delfin/storages/storages.component.ts
@@ -218,33 +218,11 @@ export class StoragesComponent implements OnInit {
                 disabled:false
             },
             {
-                "label": "Configure Metric Collection",
-
-                command: () => {
-                    this.showPerfConfigDialog(this.selectStorage);
-                },
-                disabled:false
-            },
-            {
                 "label": this.i18n.keyID['sds_block_volume_delete'],
                 command: () => {
                     this.batchDeleteStorages(this.selectStorage);
                 },
                 disabled:false
-            }
-        ];
-        this.vendorOptions = [
-            {
-                label: "Dell EMC",
-                value: 'dellemc'
-            },
-            {
-                label: "Huawei",
-                value: 'huawei'
-            },
-            {
-                label: "HPE",
-                value: 'hpe'
             }
         ];
         //All Supported storage vendors


### PR DESCRIPTION

**What type of PR is this?**
 /kind bug fix

**What this PR does / why we need it**:
Removed the repeated menu item for config metrics collection in operations menu. 
Removed the vendors object that was left behind in the storages component.
**Which issue(s) this PR fixes**:

Fixes #493 

**Test Report Added?**:
 /kind TESTED
> /kind NOT-TESTED

**Test Report**:
![image](https://user-images.githubusercontent.com/19162717/102848381-b75c3f00-443a-11eb-9853-67deaa40e96e.png)

**Special notes for your reviewer**:
