### PR TITLE
Added conditional display of resources based on device capability. Added new resources: Qtree, Filesystem and Shares for NAS devices.

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,6 +2,8 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { HostsResolver } from './business/block/modify-host/host-resolver.service';
 import { AzResolver } from './business/block/modify-host/az-resolver.service';
+import { DelfinResolver } from './business/delfin/delfin-resolver.service';
+import { DelfinService } from './business/delfin/delfin.service';
 
 const routes: Routes = [
     {path: '', redirectTo: '/home', pathMatch: 'full'},
@@ -38,7 +40,11 @@ const routes: Routes = [
     {path: 'modifyCloudFileShare/:fileShareId', loadChildren: './business/block/cloud-file-share/modify/cloud-file-share-modify.module#CloudFileShareModifyModule'},
     {path: 'fileShareDetail/:fileShareId', loadChildren: './business/block/file-share-detail/file-share-detail.module#FileShareDetailModule'},
     {path: 'services', loadChildren: './business/services/services.module#ServicesModule'},
-    {path: 'resource-monitor', loadChildren: './business/delfin/delfin.module#DelfinModule'},
+    {path: 'resource-monitor', loadChildren: './business/delfin/delfin.module#DelfinModule',
+        resolve: {
+            storages: DelfinResolver
+        }
+    },
     {path: 'performance-monitor', loadChildren: './business/delfin/performance-monitor/performance-monitor.module#PerformanceMonitorModule'},
     {path: 'registerStorage', loadChildren: './business/delfin/register-storage/register-storage.module#RegisterStorageModule'},
     {path: 'storageDetails/:storageId', loadChildren: './business/delfin/storage-details/storage-details.module#StorageDetailsModule'},
@@ -50,7 +56,9 @@ const routes: Routes = [
     exports: [RouterModule],
     providers: [
         HostsResolver,
-        AzResolver
+        AzResolver,
+        DelfinService,
+        DelfinResolver
     ]
 })
 export class AppRoutingModule {}

--- a/src/app/business/delfin/delfin-resolver.service.ts
+++ b/src/app/business/delfin/delfin-resolver.service.ts
@@ -1,0 +1,173 @@
+import { Injectable } from '@angular/core';
+import { Resolve } from '@angular/router';
+import { I18NService, HttpService, ParamStorService, Utils, Consts } from '../../shared/api';
+import { Observable } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { DelfinService } from './delfin.service';
+
+let _ = require("underscore");
+
+@Injectable()
+export class DelfinResolver implements Resolve<any> {
+  allStorages;
+  delfinStoragesUrl = Consts.API.DELFIN.storages;
+  delfinStoragePoolsUrl = Consts.API.DELFIN.storagePools;
+  delfinVolumesUrl = Consts.API.DELFIN.volumes;
+  delfinControllersUrl = Consts.API.DELFIN.controllers;
+  delfinQtreesUrl = Consts.API.DELFIN.qtrees;
+  delfinFilesystemsUrl = Consts.API.DELFIN.filesystems;
+  delfinSharesUrl = Consts.API.DELFIN.shares;
+  delfinPortsUrl = Consts.API.DELFIN.ports;
+  delfinDisksUrl = Consts.API.DELFIN.disks;
+  delfinAlertsUrl = Consts.API.DELFIN.alerts;
+  constructor(
+      private http: HttpService,
+      private paramStor: ParamStorService,
+      public ds: DelfinService
+    ) 
+    { 
+      this.ds.getAllStorages().subscribe((res)=>{
+        let storages = res.json().storages;
+        this.allStorages = storages;
+        this.allStorages.forEach((element, index, array) => {
+            //Calculate the capacities for the Widgets
+            element['capacity'] = {};
+            let percentUsage = Math.ceil((element['used_capacity']/element['total_capacity']) * 100);
+            element['capacity'].used = Utils.formatBytes(element['used_capacity']);
+            element['capacity'].free = Utils.formatBytes(element['free_capacity']);
+            element['capacity'].total = Utils.formatBytes(element['total_capacity']);
+            element['capacity'].raw = Utils.formatBytes(element['raw_capacity']);
+            element['capacity'].subscribed = Utils.formatBytes(element['subscribed_capacity']);
+            let system_used = Math.ceil((element['raw_capacity'] - element['total_capacity']));
+            element['system_used_capacity'] = system_used;
+            element['capacity'].system_used = Utils.formatBytes(element['system_used_capacity']) ;
+            element['capacity'].usage = percentUsage;
+            let capData = {
+                labels: ['Used','Free'],
+                datasets: [
+                    {
+                        data: [element['used_capacity'], element['free_capacity']],
+                        backgroundColor: [
+                            "#FF6384",
+                            "#45e800"
+                        ],
+                        hoverBackgroundColor: [
+                            "#FF6384",
+                            "#45e800"
+                        ]
+                    }]    
+            };
+
+            let opt = {
+                legend:{
+                    position: 'bottom'
+                }
+            }
+            element['capacityData'] = capData;
+            element['chartOptions'] = opt;
+            this.ds.getAccessinfoByStorageId(element['id']).subscribe((res)=>{                    
+                let accessInfo = res.json();
+                element['delfin_model'] = accessInfo['model'];
+                element['volumesExist'] = _.contains(Consts.STORAGES.resources.volumes, accessInfo['model']);
+                element['poolsExist'] = _.contains(Consts.STORAGES.resources.pools, accessInfo['model']);
+                element['controllersExist'] = _.contains(Consts.STORAGES.resources.controllers, accessInfo['model']);
+                element['portsExist'] = _.contains(Consts.STORAGES.resources.ports, accessInfo['model']);
+                element['disksExist'] = _.contains(Consts.STORAGES.resources.disks, accessInfo['model']);
+                element['qtreesExist'] = _.contains(Consts.STORAGES.resources.qtrees, accessInfo['model']);
+                element['filesystemsExist'] = _.contains(Consts.STORAGES.resources.filesystems, accessInfo['model']);
+                element['sharesExist'] = _.contains(Consts.STORAGES.resources.shares, accessInfo['model']);
+                if(element['volumesExist']){
+                    // Get all the volumes associated with the Storage device
+                    this.ds.getAllVolumes(element['id']).subscribe((res)=>{
+                        console.log("Volumes fetched")
+                        let vols = res.json().volumes;
+                        element['volumes'] = vols;
+                    }, (error)=>{
+                        console.log("Something went wrong. Could not fetch Volumes.", error)
+                    });
+                }
+
+                if(element['poolsExist']){
+                    // Get all the Storage pools associated with the Storage device 
+                    this.ds.getAllStoragePools(element['id']).subscribe((res)=>{
+                        console.log("pools fetched")
+                        let pools = res.json().storage_pools;
+                        element['storagePools'] = pools;
+                    }, (error)=>{
+                        console.log("Something went wrong. Could not fetch Storage Pools.", error)
+                    });
+                }
+                if(element['controllersExist']){
+                    // Get all the Controllers associated with the Storage device
+                    this.ds.getAllControllers(element['id']).subscribe((res)=>{
+                        console.log("Controllers fetched")
+                        let controllers = res.json().controllers;
+                        element['controllers'] = controllers;
+                    }, (error)=>{
+                        console.log("Something went wrong. Could not fetch Controllers.", error)
+                    });
+                }
+                if(element['portsExist']){
+                    
+                    // Get all the Ports associated with the Storage device
+                    this.ds.getAllPorts(element['id']).subscribe((res)=>{
+                        console.log("Ports fetched")
+                        let ports = res.json().ports;
+                        element['ports'] = ports;
+                    }, (error)=>{
+                        console.log("Something went wrong. Could not fetch Ports.", error)
+                    });
+                } 
+                if(element['disksExist']){
+                    // Get all the Disks associated with the Storage device
+                    this.ds.getAllDisks(element['id']).subscribe((res)=>{
+                        console.log("Disks fetched")
+                        let disks = res.json().disks;
+                        element['disks'] = disks;
+                    }, (error)=>{
+                        console.log("Something went wrong. Could not fetch Disks.", error)
+                    });
+                }
+                if(element['qtreesExist']){
+                    // Get all the Qtrees associated with the Storage device
+                    this.ds.getAllQtrees(element['id']).subscribe((res)=>{
+                        console.log("Qtrees fetched")
+                        let qtrees = res.json().qtrees;
+                        element['qtrees'] = qtrees;
+                    }, (error)=>{
+                        console.log("Something went wrong. Could not fetch Qtrees.", error)
+                    });
+                }
+                if(element['filesystemsExist']){
+                    // Get all the Filesystems associated with the Storage device
+                    this.ds.getAllFilesystems(element['id']).subscribe((res)=>{
+                        console.log("Filesystems fetched")
+                        let filesystems = res.json().filesystems;
+                        element['filesystems'] = filesystems;
+                    }, (error)=>{
+                        console.log("Something went wrong. Could not fetch Filesystems.", error)
+                    });
+                }
+                if(element['sharesExist']){
+                    // Get all the Shares associated with the Storage device
+                    this.ds.getAllShares(element['id']).subscribe((res)=>{
+                        console.log("Shares fetched")
+                        let shares = res.json().shares;
+                        element['shares'] = shares;
+                    }, (error)=>{
+                        console.log("Something went wrong. Could not fetch Shares.", error)
+                    });
+                } 
+            }, (error) =>{
+                console.log("Something went wrong. Could not fetch access info in resolver.");    
+            });
+        });
+      }, (error)=>{
+        console.log("Something went wrong. Could not fetch all storages in resolver.");
+      });
+    }
+  resolve(): Observable<any> {
+    console.log("All storages in resolver", this.allStorages);
+    return this.allStorages;
+  }
+}

--- a/src/app/business/delfin/delfin.service.ts
+++ b/src/app/business/delfin/delfin.service.ts
@@ -14,6 +14,9 @@ export class DelfinService {
     delfinStoragePoolsUrl = Consts.API.DELFIN.storagePools;
     delfinVolumesUrl = Consts.API.DELFIN.volumes;
     delfinControllersUrl = Consts.API.DELFIN.controllers;
+    delfinQtreesUrl = Consts.API.DELFIN.qtrees;
+    delfinFilesystemsUrl = Consts.API.DELFIN.filesystems;
+    delfinSharesUrl = Consts.API.DELFIN.shares;
     delfinPortsUrl = Consts.API.DELFIN.ports;
     delfinDisksUrl = Consts.API.DELFIN.disks;
     delfinAlertsUrl = Consts.API.DELFIN.alerts;
@@ -234,7 +237,127 @@ export class DelfinService {
     getDiskDetails(id): Observable<any> {
         return this.http.get(this.delfinDisksUrl +'/'+id);
     }
-  
+
+    //get all Qtrees
+    getAllQtrees(storageId?, qtreeId?, nativeFilesystemId?, id?, name?, status?, limit?, offset?, sort?): Observable<any> {
+        let query = "";
+        if(storageId){
+            query += "?storage_id=" + storageId;
+        }
+        if(qtreeId){
+            query += "?native_qtree_id=" + qtreeId;
+        }
+        if(nativeFilesystemId){
+            query += "?native_filesystem_id=" + nativeFilesystemId;
+        }
+        if(name){
+            query += "?name=" + name;
+        }
+        if(id){
+            query += "?id=" + id;
+        }
+        if(status){
+            query += "?status=" + status;
+        }
+        if(limit){
+            query += "?limit=" + limit;
+        }
+        if(offset){
+            query += "?offset=" + offset;
+        }
+        if(sort){
+            query += "?sort=" + sort;
+        }
+        let url =this.delfinQtreesUrl + query;
+        return this.http.get(url);
+    }
+
+    //get Qtree details
+    getQtreeDetails(id): Observable<any> {
+        return this.http.get(this.delfinQtreesUrl+'/'+id);
+    }
+
+    //get all Filesystems
+    getAllFilesystems(storageId?, nativeFilesystemId?, nativePoolId?, securityMode?, id?, name?, status?, limit?, offset?, sort?): Observable<any> {
+        let query = "";
+        if(storageId){
+            query += "?storage_id=" + storageId;
+        }
+        if(nativeFilesystemId){
+            query += "?native_filesystem_id=" + nativeFilesystemId;
+        }
+        if(nativePoolId){
+            query += "?native_pool_id=" + nativePoolId;
+        }
+        if(securityMode){
+            query += "?security_mode=" + securityMode;
+        }
+        if(id){
+            query += "?id=" + id;
+        }
+        if(name){
+            query += "?name=" + name;
+        }
+        if(status){
+            query += "?status=" + status;
+        }
+        if(limit){
+            query += "?limit=" + limit;
+        }
+        if(offset){
+            query += "?offset=" + offset;
+        }
+        if(sort){
+            query += "?sort=" + sort;
+        }
+        let url =this.delfinFilesystemsUrl + query;
+        return this.http.get(url);
+    }
+
+    //get Storage Pool details
+    getFilesystemDetails(id): Observable<any> {
+        return this.http.get(this.delfinFilesystemsUrl+'/'+id);
+    }
+
+    //get all Shares
+    getAllShares(storageId?, shareId?, nativeFilesystemId?, qtreeId?, protocol?, name?, limit?, offset?, sort?): Observable<any> {
+        let query = "";
+        if(storageId){
+            query += "?storage_id=" + storageId;
+        }
+        if(shareId){
+            query += "?native_share_id=" + shareId;
+        }
+        if(nativeFilesystemId){
+            query += "?native_filesystem_id=" + nativeFilesystemId;
+        }
+        if(qtreeId){
+            query += "?qtree_id=" + qtreeId;
+        }
+        if(protocol){
+            query += "?protocol=" + protocol;
+        }
+        if(name){
+            query += "?name=" + name;
+        }
+        if(limit){
+            query += "?limit=" + limit;
+        }
+        if(offset){
+            query += "?offset=" + offset;
+        }
+        if(sort){
+            query += "?sort=" + sort;
+        }
+        let url =this.delfinSharesUrl + query;
+        return this.http.get(url);
+    }
+
+    //get Share details
+    getShareDetails(id): Observable<any> {
+        return this.http.get(this.delfinSharesUrl+'/'+id);
+    }
+
     //get all alert sources
     getAlertSource(id): Observable<any>{
         return this.http.get(this.delfinStoragesUrl + '/' + id + '/alert-source')

--- a/src/app/business/delfin/filesystems/filesystems.component.html
+++ b/src/app/business/delfin/filesystems/filesystems.component.html
@@ -204,14 +204,6 @@
     </div>
     <div class="ui-g overview-item">
         <div class="ui-g-6">
-            Vendor / Model
-        </div>
-        <div class="ui-g-6">
-            {{ selectedStorageDetails && selectedStorageDetails.vendor}} {{selectedStorageDetails && selectedStorageDetails.model}}
-        </div>
-    </div>
-    <div class="ui-g overview-item">
-        <div class="ui-g-6">
             <span class="overview-item-label">
               Storage ID  
             </span>
@@ -224,13 +216,37 @@
     </div>
     <div class="ui-g overview-item">
         <div class="ui-g-6">
+            Type
+        </div>
+        <div class="ui-g-6">
+            {{ filesystemOverview && filesystemOverview.type}}
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            Compressed
+        </div>
+        <div class="ui-g-6">
+            {{ filesystemOverview && filesystemOverview.compressed ? "Yes" : "No"}}
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            Deduplicated
+        </div>
+        <div class="ui-g-6">
+            {{ filesystemOverview && filesystemOverview.deduplicated ? "Yes" : "No"}}
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
             <span class="overview-item-label">
-              Storage Serial No.  
+              Security Mode
             </span>
         </div>
         <div class="ui-g-6">
             <span>
-                {{ selectedStorageDetails && selectedStorageDetails.serial_number}}
+                {{ filesystemOverview && filesystemOverview.security_mode}}
             </span>
         </div>
     </div>

--- a/src/app/business/delfin/filesystems/filesystems.component.html
+++ b/src/app/business/delfin/filesystems/filesystems.component.html
@@ -1,0 +1,264 @@
+<div class="table-toolbar">
+    <div class="left">
+    </div>
+    <div class="right">
+        <div  class="ui-inputsearch">
+            <input type="text" #searchAll pInputText placeholder="{{i18n.keyID['sds_block_volume_search']}}">
+            <button pButton type="button" icon="fa-search"></button>
+        </div>
+    </div>
+</div>
+<p-dataTable [value]="filesystemsArr" [globalFilter]="searchAll"  [lazy]="true" (onLazyLoad)="loadFilesystemsLazy($event)" [expandableRows]="true"  [rows]="10" [paginator]="true" [pageLinks]="3" [rowsPerPageOptions]="[10,20,50,100]" [totalRecords]="totalRecords" #spt>
+    <p-column expander="true" styleClass="col-icon" [style]="{'width': '3%'}"></p-column>
+    <p-column field="name" header="Name">
+        <ng-template pTemplate="body" let-filesystem="rowData">
+            <a (mouseenter)="showFilesystemOverview($event, filesystem, filesystemOverviewPanel)" (mouseleave)="showFilesystemOverview($event, filesystem, filesystemOverviewPanel)">{{filesystem.name}}</a>
+        </ng-template>
+    </p-column>    
+    <p-column field="status" header="Status" [style]="{'width': '8%'}">
+        <ng-template pTemplate="body" let-filesystem="rowData">
+            <span class="storage-status-icon" [ngClass]="{normal: filesystem.status=='normal', abnormal: filesystem.status=='faulty' || filesystem.status=='offline'}"><i class="fa fa-circle"></i></span>
+            <span *ngIf="filesystem.status=='normal'">Normal</span>
+            <span *ngIf="filesystem.status=='faulty'">Faulty</span>
+            <span *ngIf="filesystem.status=='offline'">Offline</span>
+        </ng-template>
+    </p-column>
+    <p-column field="created_at" header="Created At">
+        <ng-template pTemplate="body" let-filesystem="rowData">
+            <span>{{filesystem.created_at ? (filesystem.created_at | date:'long') : '--'}}</span>
+        </ng-template>
+    </p-column>
+    <p-column field="updated_at" header="Updated At">
+        <ng-template pTemplate="body" let-filesystem="rowData">
+            <span>{{filesystem.updated_at ? (filesystem.updated_at | date:'long') : '--'}}</span>
+        </ng-template>
+    </p-column>
+    <ng-template let-filesystem pTemplate="rowexpansion">
+        <div class="details-basic-info">
+            <div class="ui-grid ui-grid-responsive ui-grid-pad ui-fluid">
+                <div class="ui-grid-col-12">
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.name}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="filesystem">
+                            {{filesystem.name}}
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.status}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="filesystem">
+                            <span class="storage-status-icon" [ngClass]="{normal: filesystem.status=='normal', abnormal: filesystem.status=='faulty' || filesystem.status=='offline'}"><i class="fa fa-circle"></i></span>
+                            <span *ngIf="filesystem.status=='normal'">Normal</span>
+                            <span *ngIf="filesystem.status=='faulty'">Faulty</span>
+                            <span *ngIf="filesystem.status=='offline'">Offline</span>
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.created_at}}:
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="filesystem">
+                            {{filesystem.created_at ? (filesystem.created_at | date:'long') : '--'}}
+                        </div>
+                    
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.id}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="filesystem">
+                            {{filesystem.id | slice:0:20}}
+                            <a *ngIf="filesystem.id.length > 20" pTooltip="{{filesystem.id}}" tooltipPosition="top">
+                                ...
+                            </a>
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.native_filesystem_id}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="filesystem">
+                            {{filesystem.native_filesystem_id | slice:0:20}}
+                            <a *ngIf="filesystem.native_filesystem_id.length > 20" pTooltip="{{filesystem.native_filesystem_id}}" tooltipPosition="top">
+                                ...
+                            </a>
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.updated_at}}:
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="filesystem">
+                            {{filesystem.updated_at ? (filesystem.updated_at | date:'long') : '--'}}
+                        </div>
+                        
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                            <div class="ui-grid-col-2">
+                                {{label.storage_id}}:
+                            </div>
+                            <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="filesystem">
+                                {{filesystem.storage_id | slice:0:20}}
+                                <a *ngIf="filesystem.storage_id.length > 20" pTooltip="{{filesystem.storage_id}}" tooltipPosition="top">
+                                    ...
+                                </a>
+                            </div>
+                            <div class="ui-grid-col-2">
+                                {{label.native_pool_id}}:
+                            </div>
+                            <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="filesystem">
+                                {{filesystem.native_pool_id | slice:0:20}}
+                                <a *ngIf="filesystem.native_pool_id.length > 20" pTooltip="{{filesystem.native_pool_id}}" tooltipPosition="top">
+                                    ...
+                                </a>
+                            </div>
+                            
+                            <div class="ui-grid-col-2">
+                                {{label.type}}:
+                            </div>
+                            <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="filesystem">
+                                {{filesystem.type ? filesystem.type : '--'}}
+                            </div>
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.security_mode}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="filesystem">
+                            {{ filesystem.security_mode }}
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.compressed}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="filesystem">
+                            {{ filesystem.compressed }}
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.deduplicated}}:
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="filesystem">
+                            {{ filesystem.deduplicated }}
+                        </div>
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-12">
+                            <span>Capacity Summary</span>
+                        </div>
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.free_capacity}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="filesystem">
+                            {{ filesystem.capacity.free}}
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.used_capacity}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="filesystem">
+                            {{ filesystem.capacity.used}}
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.total_capacity}}:
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="filesystem">
+                            {{ filesystem.capacity.total}}
+                        </div>
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.subscribed_capacity}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="filesystem">
+                            {{ filesystem.capacity.subscribed ? filesystem.capacity.subscribed : '--'}}
+                        </div>
+                        <div class="ui-grid-col-2">
+                            
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="filesystem">
+                            
+                        </div>
+                        <div class="ui-grid-col-2">
+                            
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="filesystem">
+                            
+                        </div>
+                    </div>
+                    
+                </div>
+            </div>
+        </div>
+    </ng-template>    
+</p-dataTable>
+
+<p-overlayPanel styleClass="overview-panel" #filesystemOverviewPanel>
+    <div class="ui-g overview-title">
+        <h4>{{filesystemOverview && filesystemOverview.name}}</h4>
+    </div>
+    <div class="ui-g ui-g-nopad overview-item" >
+        <div class="ui-g-6">
+            <span class="overview-item-label">Status: </span>
+        </div>
+        <div class="ui-g-6">
+            <span class="storage-status-icon" [ngClass]="{normal:  filesystemOverview && filesystemOverview.status =='normal', abnormal: filesystemOverview && filesystemOverview.status =='faulty'}"><i class="fa fa-circle"></i></span>
+            <span *ngIf="filesystemOverview && filesystemOverview.status=='normal'">Normal</span>
+            <span *ngIf=" filesystemOverview && filesystemOverview.status=='faulty'">Faulty</span>
+            <span *ngIf=" filesystemOverview && filesystemOverview.status=='offline'">Offline</span>
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            Vendor / Model
+        </div>
+        <div class="ui-g-6">
+            {{ selectedStorageDetails && selectedStorageDetails.vendor}} {{selectedStorageDetails && selectedStorageDetails.model}}
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            <span class="overview-item-label">
+              Storage ID  
+            </span>
+        </div>
+        <div class="ui-g-6">
+            <span>
+                {{ filesystemOverview && filesystemOverview.storage_id}}
+            </span>
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            <span class="overview-item-label">
+              Storage Serial No.  
+            </span>
+        </div>
+        <div class="ui-g-6">
+            <span>
+                {{ selectedStorageDetails && selectedStorageDetails.serial_number}}
+            </span>
+        </div>
+    </div>
+    <hr />
+    <div class="ui-g overview-item">
+        <div class="ui-g-12">
+            <span class="overview-item-label">Usable Capacity Summary</span>
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div *ngIf="filesystemOverview && filesystemOverview.capacity" class="capacity-stats-bar">
+            <table class="capacity-table" *ngIf="filesystemOverview && filesystemOverview.capacity">
+                <thead>
+                    <th class="capacity-header">Free</th>
+                    <th class="capacity-header">Used</th>
+                    <th class="capacity-header">Total</th>
+                </thead>
+                <tbody>
+                    <td class="capacity-field"><span class="free-storage">{{filesystemOverview.capacity && filesystemOverview.capacity.free ? filesystemOverview.capacity.free : '-'}} </span></td>
+                    <td class="capacity-field"><span class="used-storage">{{filesystemOverview.capacity && filesystemOverview.capacity.used ? filesystemOverview.capacity.used : '-'}} </span></td>
+                    <td class="capacity-field"><span class="total-storage">{{filesystemOverview.capacity && filesystemOverview.capacity.total ? filesystemOverview.capacity.total : '-'}} </span></td>
+                </tbody>
+            </table>
+            <div class="storage-usage-bar" >
+                <p-progressBar [ngClass]="{'capacity-usage-zero': filesystemOverview.capacity.usage == 0, 'capacity-usage-normal': filesystemOverview.capacity.usage > 0 && filesystemOverview.capacity.usage < 75, 
+                    'capacity-usage-warning': filesystemOverview.capacity.usage > 75 && filesystemOverview.capacity.usage < 95, 
+                    'capacity-usage-full' : filesystemOverview.capacity.usage > 95 }" [value]="filesystemOverview.capacity.usage" unit="% used"></p-progressBar>
+            </div>
+        </div>
+    </div>
+</p-overlayPanel>

--- a/src/app/business/delfin/filesystems/filesystems.component.ts
+++ b/src/app/business/delfin/filesystems/filesystems.component.ts
@@ -1,0 +1,116 @@
+import { Component, OnInit, Input, ViewContainerRef, ViewChild, Directive, ElementRef, HostBinding, HostListener } from '@angular/core';
+import { Router, ActivatedRoute } from '@angular/router';
+import { I18NService, Utils } from 'app/shared/api';
+import { FormControl, FormGroup, FormBuilder, Validators, ValidatorFn, AbstractControl } from '@angular/forms';
+import { AppService } from 'app/app.service';
+import { I18nPluralPipe } from '@angular/common';
+import { trigger, state, style, transition, animate } from '@angular/animations';
+import { Message, MenuItem ,ConfirmationService, LazyLoadEvent} from '../../../components/common/api';
+import { DelfinService } from '../delfin.service';
+import { OverlayPanel } from 'app/components/overlaypanel/overlaypanel';
+
+
+let _ = require("underscore");
+@Component({
+    selector: 'app-delfin-filesystems',
+    templateUrl: 'filesystems.component.html',
+    providers: [ConfirmationService],
+    styleUrls: [],
+    animations: []
+})
+export class FilesystemsComponent implements OnInit {
+    @Input() selectedStorage;
+    filesystemsArr = [];
+    allPools: any = [];
+    allStorages: any = [];
+    selectedStorageId: any;
+    selectedStorageDetails: any;
+    items: any;
+    capacityData: any;
+    dataSource: any = [];
+    totalRecords: number;
+    filesystemOverview: any;
+    label = {
+        name: this.i18n.keyID["sds_block_volume_name"],
+        description: this.i18n.keyID["sds_block_volume_descri"],
+        native_filesystem_id: "Native Filesystem ID",
+        native_pool_id: "Native Pool ID",
+        storage_id: "Storage ID",
+        type: "Type",
+        security_mode : "Security Mode",
+        status: "Status",
+        created_at: "Created At",
+        updated_at: "Updated At",
+        free_capacity: "Free Capacity",
+        used_capacity: "Used Capacity",
+        total_capacity: "Total Capacity",
+        subscribed_capacity: "Subscribed Capacity",
+        compressed: "Compressed",
+        deduplicated: "De-duplicated",
+        worm: "WORM",
+        id: "Delfin ID",
+    };
+
+    constructor(
+        private ActivatedRoute: ActivatedRoute,
+        public i18n: I18NService,
+        private confirmationService: ConfirmationService,
+        private fb: FormBuilder,
+        private ds: DelfinService
+    ) {
+       
+    }
+
+    ngOnInit() {
+        this.getStorageById(this.selectedStorage);
+        this.ds.getAllFilesystems(this.selectedStorage).subscribe((res)=>{
+            this.dataSource = res.json().filesystems;
+            
+            this.dataSource.forEach((element, index) => {
+                //Calculate the capacities for the Widgets
+                element['capacity'] = {};
+                let percentUsage = Math.ceil((element['used_capacity']/element['total_capacity']) * 100);
+                element['capacity'].used = Utils.formatBytes(element['used_capacity']);
+                element['capacity'].free = Utils.formatBytes(element['free_capacity']);
+                element['capacity'].total = Utils.formatBytes(element['total_capacity']);
+                element['capacity'].usage = percentUsage;
+            });
+            
+            this.totalRecords = this.dataSource.length;
+            this.filesystemsArr = this.dataSource.slice(0, 10);
+            
+        }, (error)=>{
+            console.log("Something went wrong. Could not fetch Filesystems.", error)
+        });
+    }
+
+    loadFilesystemsLazy(event: LazyLoadEvent){
+        if(this.dataSource){
+            this.filesystemsArr = this.dataSource.slice(event.first, (event.first + event.rows));
+        }
+    }
+    
+    getAllStorages(){
+        this.ds.getAllStorages().subscribe((res)=>{
+            let storages = res.json().storages;
+            this.allStorages = storages;
+        }, (error)=>{
+            console.log("Something went wrong. Could not fetch all storages", error);
+        })
+    }
+
+    getStorageById(id){
+        this.ds.getStorageById(id).subscribe((res)=>{
+            let storage = res.json();
+            this.selectedStorageDetails  = storage;
+        }, (error)=>{
+            console.log("Something went wrong. Could not fetch storage", error);
+        })
+    }
+
+    showFilesystemOverview(event, filesystem, overlaypanel: OverlayPanel){
+        this.filesystemOverview = filesystem;
+        overlaypanel.toggle(event);
+    }
+    
+}

--- a/src/app/business/delfin/qtrees/qtrees.component.html
+++ b/src/app/business/delfin/qtrees/qtrees.component.html
@@ -1,0 +1,214 @@
+<div class="table-toolbar">
+    <div class="left">
+    </div>
+    <div class="right">
+        <div  class="ui-inputsearch">
+            <input type="text" #searchAll pInputText placeholder="{{i18n.keyID['sds_block_volume_search']}}">
+            <button pButton type="button" icon="fa-search"></button>
+        </div>
+    </div>
+</div>
+<p-dataTable [value]="qtreesArr" [globalFilter]="searchAll"  [lazy]="true" (onLazyLoad)="loadQtreesLazy($event)" [expandableRows]="true"  [rows]="10" [paginator]="true" [pageLinks]="3" [rowsPerPageOptions]="[10,20,50,100]" [totalRecords]="totalRecords" #spt>
+    <p-column expander="true" styleClass="col-icon" [style]="{'width': '3%'}"></p-column>
+    <p-column field="name" header="Name">
+        <ng-template pTemplate="body" let-qtree="rowData">
+            <!-- {{qtree.name}} -->
+            <a (mouseenter)="showQtreeOverview($event, qtree, qtreeOverviewPanel)" (mouseleave)="showQtreeOverview($event, qtree, qtreeOverviewPanel)">{{qtree.name}}</a>
+        </ng-template>
+    </p-column>    
+    <p-column field="status" header="Status">
+        <ng-template pTemplate="body" let-qtree="rowData">
+            <span class="storage-status-icon" [ngClass]="{normal: qtree.status=='normal', abnormal: qtree.status=='abnormal' || qtree.status=='unknown' || qtree.status=='offline'}"><i class="fa fa-circle"></i></span>
+            <span *ngIf="qtree.status=='normal'">Normal</span>
+            <span *ngIf="qtree.status=='abnormal' || qtree.status=='unknown'">Unknown</span>
+            <span *ngIf="qtree.status=='offline'">Offline</span>
+        </ng-template>
+    </p-column>
+    <p-column field="created_at" header="Created At">
+        <ng-template pTemplate="body" let-qtree="rowData">
+            <span>{{qtree.created_at ? (qtree.created_at | date:'long') : '--'}}</span>
+        </ng-template>
+    </p-column>
+    <p-column field="updated_at" header="Updated At">
+        <ng-template pTemplate="body" let-qtree="rowData">
+            <span>{{qtree.updated_at ? (qtree.updated_at | date:'long') : '--'}}</span>
+        </ng-template>
+    </p-column>
+    <ng-template let-qtree pTemplate="rowexpansion">
+        <div class="details-basic-info">
+            <div class="ui-grid ui-grid-responsive ui-grid-pad ui-fluid">
+                <div class="ui-grid-col-12">
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.name}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="qtree">
+                            {{qtree.name}}
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.status}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="qtree">
+                            <span class="storage-status-icon" [ngClass]="{normal: qtree.status=='normal', abnormal: qtree.status=='abnormal' || qtree.status=='unknown' || qtree.status=='offline'}"><i class="fa fa-circle"></i></span>
+                            <span *ngIf="qtree.status=='normal'">Normal</span>
+                            <span *ngIf="qtree.status=='abnormal' || qtree.status=='unknown'">Unknown</span>
+                            <span *ngIf="qtree.status=='offline'">Offline</span>
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.created_at}}:
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="qtree">
+                            {{qtree.created_at ? (qtree.created_at | date:'long') : '--'}}
+                        </div>
+                    
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.id}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="qtree">
+                            {{qtree.id | slice:0:20}}
+                            <a *ngIf="qtree.id.length > 20" pTooltip="{{qtree.id}}" tooltipPosition="top">
+                                ...
+                            </a>
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.native_qtree_id}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="qtree">
+                            {{qtree.native_qtree_id | slice:0:20}}
+                            <a *ngIf="qtree.native_qtree_id.length > 20" pTooltip="{{qtree.native_qtree_id}}" tooltipPosition="top">
+                                ...
+                            </a>
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.updated_at}}:
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="qtree">
+                            {{qtree.updated_at ? (qtree.updated_at | date:'long') : '--'}}
+                        </div>
+                       
+                        
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.storage_id}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="qtree">
+                            {{qtree.storage_id | slice:0:20}}
+                            <a *ngIf="qtree.storage_id.length > 20" pTooltip="{{qtree.storage_id}}" tooltipPosition="top">
+                                ...
+                            </a>
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.native_filesystem_id}}:  
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="qtree">
+                            {{qtree.native_filesystem_id ? qtree.native_filesystem_id : '--'}}           
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.security_mode}}:
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="qtree">
+                            {{qtree.security_mode ? qtree.security_mode : '--'}}           
+                        </div>
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.path}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="qtree">
+                            {{qtree.path ? qtree.path : '--'}}   
+                        </div>
+                        <div class="ui-grid-col-2">
+
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="qtree">
+                            
+                        </div>
+                        <div class="ui-grid-col-2">
+                            
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="qtree">
+                            
+                        </div>
+                </div>
+                </div>
+            </div>
+        </div>
+    </ng-template>    
+</p-dataTable>
+
+<p-overlayPanel styleClass="overview-panel" #qtreeOverviewPanel>
+    <div class="ui-g overview-title">
+        <h4>{{qtreeOverview && qtreeOverview.name}}</h4>
+    </div>
+    <div class="ui-g ui-g-nopad overview-item" >
+        <div class="ui-g-6">
+            <span class="overview-item-label">Status: </span>
+        </div>
+        <div *ngIf="qtreeOverview" class="ui-g-6">
+            <span class="storage-status-icon" [ngClass]="{normal:  qtreeOverview && qtreeOverview.status =='normal', abnormal: qtreeOverview && qtreeOverview.status =='abnormal' || qtreeOverview.status =='unknown'}"><i class="fa fa-circle"></i></span>
+            <span *ngIf="qtreeOverview && qtreeOverview.status=='normal'">Normal</span>
+            <span *ngIf=" qtreeOverview && qtreeOverview.status=='abnormal' || qtreeOverview.status=='unknown'">Unknown</span>
+            <span *ngIf=" qtreeOverview && qtreeOverview.status=='offline'">Offline</span>
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            Vendor / Model
+        </div>
+        <div class="ui-g-6">
+            {{ selectedStorageDetails && selectedStorageDetails.vendor}} {{selectedStorageDetails && selectedStorageDetails.model}}
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            <span class="overview-item-label">
+              Storage ID  
+            </span>
+        </div>
+        <div class="ui-g-6">
+            <span>
+                {{ qtreeOverview && qtreeOverview.storage_id}}
+            </span>
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            <span class="overview-item-label">
+              Storage Serial No.  
+            </span>
+        </div>
+        <div class="ui-g-6">
+            <span>
+                {{ selectedStorageDetails && selectedStorageDetails.serial_number}}
+            </span>
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            Security Mode
+        </div>
+        <div class="ui-g-6">
+            {{ qtreeOverview && qtreeOverview.security_mode}}
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            Path
+        </div>
+        <div class="ui-g-6">
+            {{qtreeOverview && qtreeOverview.path}}
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            
+        </div>
+        <div class="ui-g-6">
+            
+        </div>
+    </div>
+    <hr />
+</p-overlayPanel>

--- a/src/app/business/delfin/qtrees/qtrees.component.ts
+++ b/src/app/business/delfin/qtrees/qtrees.component.ts
@@ -1,0 +1,103 @@
+import { Component, OnInit, Input, ViewContainerRef, ViewChild, Directive, ElementRef, HostBinding, HostListener } from '@angular/core';
+import { Router, ActivatedRoute } from '@angular/router';
+import { I18NService, Utils } from 'app/shared/api';
+import { FormControl, FormGroup, FormBuilder, Validators, ValidatorFn, AbstractControl } from '@angular/forms';
+import { AppService } from 'app/app.service';
+import { I18nPluralPipe } from '@angular/common';
+import { trigger, state, style, transition, animate } from '@angular/animations';
+import { Message, MenuItem ,ConfirmationService, LazyLoadEvent} from '../../../components/common/api';
+import { DelfinService } from '../delfin.service';
+import { OverlayPanel } from 'app/components/overlaypanel/overlaypanel';
+
+
+let _ = require("underscore");
+@Component({
+    selector: 'app-delfin-qtrees',
+    templateUrl: 'qtrees.component.html',
+    providers: [ConfirmationService],
+    styleUrls: [],
+    animations: []
+})
+export class QtreesComponent implements OnInit {
+    @Input() selectedStorage;
+    qtreesArr = [];
+    allPools: any = [];
+    allStorages: any = [];
+    selectedStorageId: any;
+    selectedStorageDetails: any;
+    items: any;
+    capacityData: any;
+    dataSource: any = [];
+    totalRecords: number;
+    qtreeOverview: any;
+    label = {
+        name: this.i18n.keyID["sds_block_volume_name"],
+        native_qtree_id: "Native Qtree ID",
+        native_filesystem_id: "Native Filesystem ID",
+        storage_id: "Storage ID",
+        status: "Status",
+        created_at: "Created At",
+        updated_at: "Updated At",
+        path: "Path",
+        quota_id: "Quota ID",
+        security_mode : "Security Mode",
+        id: "Delfin ID",
+    };
+
+    constructor(
+        private ActivatedRoute: ActivatedRoute,
+        public i18n: I18NService,
+        private confirmationService: ConfirmationService,
+        private fb: FormBuilder,
+        private ds: DelfinService
+    ) {
+       
+    }
+
+    ngOnInit() {
+        this.getStorageById(this.selectedStorage);
+        this.ds.getAllQtrees(this.selectedStorage).subscribe((res)=>{
+            this.dataSource = res.json().qtrees;
+            
+            this.dataSource.forEach((element, index) => {
+               
+            });
+            
+            this.totalRecords = this.dataSource.length;
+            this.qtreesArr = this.dataSource.slice(0, 10);
+            
+        }, (error)=>{
+            console.log("Something went wrong. Could not fetch Qtrees.", error)
+        });
+    }
+
+    loadQtreesLazy(event: LazyLoadEvent){
+        if(this.dataSource){
+            this.qtreesArr = this.dataSource.slice(event.first, (event.first + event.rows));
+        }
+    }
+    
+    getAllStorages(){
+        this.ds.getAllStorages().subscribe((res)=>{
+            let storages = res.json().storages;
+            this.allStorages = storages;
+        }, (error)=>{
+            console.log("Something went wrong. Could not fetch all storages", error);
+        })
+    }
+
+    getStorageById(id){
+        this.ds.getStorageById(id).subscribe((res)=>{
+            let storage = res.json();
+            this.selectedStorageDetails  = storage;
+        }, (error)=>{
+            console.log("Something went wrong. Could not fetch storage", error);
+        })
+    }
+
+    showQtreeOverview(event, qtree, overlaypanel: OverlayPanel){
+        this.qtreeOverview = qtree;
+        overlaypanel.toggle(event);
+    }
+    
+}

--- a/src/app/business/delfin/shares/shares.component.html
+++ b/src/app/business/delfin/shares/shares.component.html
@@ -1,0 +1,214 @@
+<div class="table-toolbar">
+    <div class="left">
+    </div>
+    <div class="right">
+        <div  class="ui-inputsearch">
+            <input type="text" #searchAll pInputText placeholder="{{i18n.keyID['sds_block_volume_search']}}">
+            <button pButton type="button" icon="fa-search"></button>
+        </div>
+    </div>
+</div>
+<p-dataTable [value]="sharesArr" [globalFilter]="searchAll"  [lazy]="true" (onLazyLoad)="loadSharesLazy($event)" [expandableRows]="true"  [rows]="10" [paginator]="true" [pageLinks]="3" [rowsPerPageOptions]="[10,20,50,100]" [totalRecords]="totalRecords" #spt>
+    <p-column expander="true" styleClass="col-icon" [style]="{'width': '3%'}"></p-column>
+    <p-column field="name" header="Name">
+        <ng-template pTemplate="body" let-share="rowData">
+            <!-- {{share.name}} -->
+            <a (mouseenter)="showShareOverview($event, share, shareOverviewPanel)" (mouseleave)="showShareOverview($event, share, shareOverviewPanel)">{{share.name}}</a>
+        </ng-template>
+    </p-column>    
+    <p-column field="status" header="Status">
+        <ng-template pTemplate="body" let-share="rowData">
+            <span class="storage-status-icon" [ngClass]="{normal: share.status=='normal', abnormal: share.status=='abnormal' || share.status=='unknown' || share.status=='offline'}"><i class="fa fa-circle"></i></span>
+            <span *ngIf="share.status=='normal'">Normal</span>
+            <span *ngIf="share.status=='abnormal' || share.status=='unknown'">Unknown</span>
+            <span *ngIf="share.status=='offline'">Offline</span>
+        </ng-template>
+    </p-column>
+    <p-column field="created_at" header="Created At">
+        <ng-template pTemplate="body" let-share="rowData">
+            <span>{{share.created_at ? (share.created_at | date:'long') : '--'}}</span>
+        </ng-template>
+    </p-column>
+    <p-column field="updated_at" header="Updated At">
+        <ng-template pTemplate="body" let-share="rowData">
+            <span>{{share.updated_at ? (share.updated_at | date:'long') : '--'}}</span>
+        </ng-template>
+    </p-column>
+    <ng-template let-share pTemplate="rowexpansion">
+        <div class="details-basic-info">
+            <div class="ui-grid ui-grid-responsive ui-grid-pad ui-fluid">
+                <div class="ui-grid-col-12">
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.name}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="share">
+                            {{share.name}}
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.status}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="share">
+                            <span class="storage-status-icon" [ngClass]="{normal: share.status=='normal', abnormal: share.status=='abnormal' || share.status=='unknown' || share.status=='offline'}"><i class="fa fa-circle"></i></span>
+                            <span *ngIf="share.status=='normal'">Normal</span>
+                            <span *ngIf="share.status=='abnormal' || share.status=='unknown'">Unknown</span>
+                            <span *ngIf="share.status=='offline'">Offline</span>
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.created_at}}:
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="share">
+                            {{share.created_at ? (share.created_at | date:'long') : '--'}}
+                        </div>
+                    
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.id}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="share">
+                            {{share.id | slice:0:20}}
+                            <a *ngIf="share.id.length > 20" pTooltip="{{share.id}}" tooltipPosition="top">
+                                ...
+                            </a>
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.native_share_id}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="share">
+                            {{share.native_share_id | slice:0:20}}
+                            <a *ngIf="share.native_share_id.length > 20" pTooltip="{{share.native_share_id}}" tooltipPosition="top">
+                                ...
+                            </a>
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.updated_at}}:
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="share">
+                            {{share.updated_at ? (share.updated_at | date:'long') : '--'}}
+                        </div>
+                       
+                        
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.storage_id}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="share">
+                            {{share.storage_id | slice:0:20}}
+                            <a *ngIf="share.storage_id.length > 20" pTooltip="{{share.storage_id}}" tooltipPosition="top">
+                                ...
+                            </a>
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.native_filesystem_id}}:  
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="share">
+                            {{share.native_filesystem_id ? share.native_filesystem_id : '--'}}           
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.protocol}}:
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="share">
+                            {{share.protocol ? share.protocol : '--'}}           
+                        </div>
+                    </div>
+                    <div class="ui-grid-row details-basic-item-class">
+                        <div class="ui-grid-col-2">
+                            {{label.path}}:
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="share">
+                            {{share.path ? share.path : '--'}}   
+                        </div>
+                        <div class="ui-grid-col-2">
+                            {{label.native_qtree_id}}:  
+                        </div>
+                        <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="share">
+                            {{share.native_qtree_id ? share.native_qtree_id : '--'}}           
+                        </div>
+                        <div class="ui-grid-col-2">
+                            
+                        </div>
+                        <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="share">
+                            
+                        </div>
+                </div>
+                </div>
+            </div>
+        </div>
+    </ng-template>    
+</p-dataTable>
+
+<p-overlayPanel styleClass="overview-panel" #shareOverviewPanel>
+    <div class="ui-g overview-title">
+        <h4>{{shareOverview && shareOverview.name}}</h4>
+    </div>
+    <div class="ui-g ui-g-nopad overview-item" >
+        <div class="ui-g-6">
+            <span class="overview-item-label">Status: </span>
+        </div>
+        <div *ngIf="shareOverview" class="ui-g-6">
+            <span class="storage-status-icon" [ngClass]="{normal:  shareOverview && shareOverview.status =='normal', abnormal: shareOverview && shareOverview.status =='abnormal' || shareOverview.status =='unknown'}"><i class="fa fa-circle"></i></span>
+            <span *ngIf="shareOverview && shareOverview.status=='normal'">Normal</span>
+            <span *ngIf=" shareOverview && shareOverview.status=='abnormal' || shareOverview.status=='unknown'">Unknown</span>
+            <span *ngIf=" shareOverview && shareOverview.status=='offline'">Offline</span>
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            Vendor / Model
+        </div>
+        <div class="ui-g-6">
+            {{ selectedStorageDetails && selectedStorageDetails.vendor}} {{selectedStorageDetails && selectedStorageDetails.model}}
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            <span class="overview-item-label">
+              Storage ID  
+            </span>
+        </div>
+        <div class="ui-g-6">
+            <span>
+                {{ shareOverview && shareOverview.storage_id}}
+            </span>
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            <span class="overview-item-label">
+              Storage Serial No.  
+            </span>
+        </div>
+        <div class="ui-g-6">
+            <span>
+                {{ selectedStorageDetails && selectedStorageDetails.serial_number}}
+            </span>
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            Protocol
+        </div>
+        <div class="ui-g-6">
+            {{ shareOverview && shareOverview.protocol}}
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            Path
+        </div>
+        <div class="ui-g-6">
+            {{shareOverview && shareOverview.path}}
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            
+        </div>
+        <div class="ui-g-6">
+            
+        </div>
+    </div>
+    <hr />
+</p-overlayPanel>

--- a/src/app/business/delfin/shares/shares.component.ts
+++ b/src/app/business/delfin/shares/shares.component.ts
@@ -1,0 +1,103 @@
+import { Component, OnInit, Input, ViewContainerRef, ViewChild, Directive, ElementRef, HostBinding, HostListener } from '@angular/core';
+import { Router, ActivatedRoute } from '@angular/router';
+import { I18NService, Utils } from 'app/shared/api';
+import { FormControl, FormGroup, FormBuilder, Validators, ValidatorFn, AbstractControl } from '@angular/forms';
+import { AppService } from 'app/app.service';
+import { I18nPluralPipe } from '@angular/common';
+import { trigger, state, style, transition, animate } from '@angular/animations';
+import { Message, MenuItem ,ConfirmationService, LazyLoadEvent} from '../../../components/common/api';
+import { DelfinService } from '../delfin.service';
+import { OverlayPanel } from 'app/components/overlaypanel/overlaypanel';
+
+
+let _ = require("underscore");
+@Component({
+    selector: 'app-delfin-shares',
+    templateUrl: 'shares.component.html',
+    providers: [ConfirmationService],
+    styleUrls: [],
+    animations: []
+})
+export class SharesComponent implements OnInit {
+    @Input() selectedStorage;
+    sharesArr = [];
+    allPools: any = [];
+    allStorages: any = [];
+    selectedStorageId: any;
+    selectedStorageDetails: any;
+    items: any;
+    capacityData: any;
+    dataSource: any = [];
+    totalRecords: number;
+    shareOverview: any;
+    label = {
+        name: this.i18n.keyID["sds_block_volume_name"],
+        native_share_id: "Native Share ID",
+        native_qtree_id: "Native Qtree ID",
+        native_filesystem_id: "Native Filesystem ID",
+        storage_id: "Storage ID",
+        status: "Status",
+        created_at: "Created At",
+        updated_at: "Updated At",
+        path: "Path",
+        protocol : "Protocol",
+        id: "Delfin ID",
+    };
+
+    constructor(
+        private ActivatedRoute: ActivatedRoute,
+        public i18n: I18NService,
+        private confirmationService: ConfirmationService,
+        private fb: FormBuilder,
+        private ds: DelfinService
+    ) {
+       
+    }
+
+    ngOnInit() {
+        this.getStorageById(this.selectedStorage);
+        this.ds.getAllShares(this.selectedStorage).subscribe((res)=>{
+            this.dataSource = res.json().shares;
+            
+            this.dataSource.forEach((element, index) => {
+               
+            });
+            
+            this.totalRecords = this.dataSource.length;
+            this.sharesArr = this.dataSource.slice(0, 10);
+            
+        }, (error)=>{
+            console.log("Something went wrong. Could not fetch Shares.", error)
+        });
+    }
+
+    loadSharesLazy(event: LazyLoadEvent){
+        if(this.dataSource){
+            this.sharesArr = this.dataSource.slice(event.first, (event.first + event.rows));
+        }
+    }
+    
+    getAllStorages(){
+        this.ds.getAllStorages().subscribe((res)=>{
+            let storages = res.json().storages;
+            this.allStorages = storages;
+        }, (error)=>{
+            console.log("Something went wrong. Could not fetch all storages", error);
+        })
+    }
+
+    getStorageById(id){
+        this.ds.getStorageById(id).subscribe((res)=>{
+            let storage = res.json();
+            this.selectedStorageDetails  = storage;
+        }, (error)=>{
+            console.log("Something went wrong. Could not fetch storage", error);
+        })
+    }
+
+    showShareOverview(event, share, overlaypanel: OverlayPanel){
+        this.shareOverview = share;
+        overlaypanel.toggle(event);
+    }
+    
+}

--- a/src/app/business/delfin/storage-details/storage-details.component.html
+++ b/src/app/business/delfin/storage-details/storage-details.component.html
@@ -168,30 +168,30 @@
                     </div>
                 <div class="configuration-tabs">
                     <p-tabView styleClass="ui-tabview-large" (onChange)="changeConfigTab($event)" [activeIndex]="configTabIndex"> 
-                        <p-tabPanel header="Volumes">
+                        <p-tabPanel *ngIf="poolsExist" header="Storage pools">
+                            <app-delfin-storage-pools [selectedStorage]="selectedStorageId"></app-delfin-storage-pools>
+                        </p-tabPanel>
+                        <p-tabPanel *ngIf="volumesExist" header="Volumes">
                             <ng-template pTemplate="content">
                                 <app-delfin-volumes [selectedStorage]="selectedStorageId"></app-delfin-volumes>
                             </ng-template>
                         </p-tabPanel>
-                        <p-tabPanel header="Storage pools">
-                            <app-delfin-storage-pools [selectedStorage]="selectedStorageId"></app-delfin-storage-pools>
-                        </p-tabPanel>
-                        <p-tabPanel header="Controllers">
+                        <p-tabPanel *ngIf="controllersExist" header="Controllers">
                             <app-delfin-controllers [selectedStorage]="selectedStorageId"></app-delfin-controllers>
                         </p-tabPanel>
-                        <p-tabPanel header="Ports">
+                        <p-tabPanel *ngIf="portsExist" header="Ports">
                             <app-delfin-ports [selectedStorage]="selectedStorageId"></app-delfin-ports>
                         </p-tabPanel>
-                        <p-tabPanel header="Disks">
+                        <p-tabPanel *ngIf="disksExist" header="Disks">
                             <app-delfin-disks [selectedStorage]="selectedStorageId"></app-delfin-disks>
                         </p-tabPanel>
-                        <p-tabPanel header="Qtrees">
+                        <p-tabPanel *ngIf="qtreesExist" header="Qtrees">
                             <app-delfin-qtrees [selectedStorage]="selectedStorageId"></app-delfin-qtrees>
                         </p-tabPanel>
-                        <p-tabPanel header="Filesystems">
+                        <p-tabPanel *ngIf="filesystemsExist" header="Filesystems">
                             <app-delfin-filesystems [selectedStorage]="selectedStorageId"></app-delfin-filesystems>
                         </p-tabPanel>
-                        <p-tabPanel header="Shares">
+                        <p-tabPanel *ngIf="sharesExist" header="Shares">
                             <app-delfin-shares [selectedStorage]="selectedStorageId"></app-delfin-shares>
                         </p-tabPanel>
                     </p-tabView>

--- a/src/app/business/delfin/storage-details/storage-details.component.html
+++ b/src/app/business/delfin/storage-details/storage-details.component.html
@@ -185,6 +185,15 @@
                         <p-tabPanel header="Disks">
                             <app-delfin-disks [selectedStorage]="selectedStorageId"></app-delfin-disks>
                         </p-tabPanel>
+                        <p-tabPanel header="Qtrees">
+                            <app-delfin-qtrees [selectedStorage]="selectedStorageId"></app-delfin-qtrees>
+                        </p-tabPanel>
+                        <p-tabPanel header="Filesystems">
+                            <app-delfin-filesystems [selectedStorage]="selectedStorageId"></app-delfin-filesystems>
+                        </p-tabPanel>
+                        <p-tabPanel header="Shares">
+                            <app-delfin-shares [selectedStorage]="selectedStorageId"></app-delfin-shares>
+                        </p-tabPanel>
                     </p-tabView>
                 </div>
             </p-tabPanel>

--- a/src/app/business/delfin/storage-details/storage-details.component.ts
+++ b/src/app/business/delfin/storage-details/storage-details.component.ts
@@ -50,6 +50,14 @@ export class StorageDetailsComponent implements OnInit {
     perfMetricsConfigForm: any;
     showperfMetricsConfigForm: boolean = false;
     performanceMonitorURL: any = "";
+    volumesExist: boolean = false;
+    poolsExist: boolean = false;
+    controllersExist: boolean = false;
+    portsExist: boolean = false;
+    disksExist: boolean = false;
+    qtreesExist: boolean = false;
+    filesystemsExist: boolean = false;
+    sharesExist: boolean = false;
     msgs: Message[];
 
     label = {
@@ -166,22 +174,37 @@ export class StorageDetailsComponent implements OnInit {
     }
 
     getStorageById(id){
-        this.ds.getStorageById(id).subscribe((res)=>{
+        this.ds.getStorageById(id).subscribe((storageRes)=>{
             let storageDevice;
-            storageDevice = res.json();
-            storageDevice['capacity'] = {};
-            let percentUsage = Math.ceil((storageDevice['used_capacity']/storageDevice['total_capacity']) * 100);
-            storageDevice['capacity'].used = Utils.formatBytes(storageDevice['used_capacity']);
-            storageDevice['capacity'].free = Utils.formatBytes(storageDevice['free_capacity']);
-            storageDevice['capacity'].total = Utils.formatBytes(storageDevice['total_capacity']);
-            storageDevice['capacity'].raw = Utils.formatBytes(storageDevice['raw_capacity']);
-            storageDevice['capacity'].subscribed = Utils.formatBytes(storageDevice['subscribed_capacity']);
-            let system_used = Math.ceil((storageDevice['raw_capacity'] - storageDevice['total_capacity']));
-            storageDevice['system_used_capacity'] = system_used;
-            storageDevice['capacity'].system_used = Utils.formatBytes(storageDevice['system_used_capacity']) ;
-            storageDevice['capacity'].usage = percentUsage;
+            storageDevice = storageRes.json();
+            this.ds.getAccessinfoByStorageId(this.selectedStorageId).subscribe((res)=>{
+                let accessInfo = res.json();
+                storageDevice['delfin_model'] = accessInfo['model'];
+                this.volumesExist = _.contains(Consts.STORAGES.resources.volumes, accessInfo['model']);
+                this.poolsExist = _.contains(Consts.STORAGES.resources.pools, accessInfo['model']);
+                this.controllersExist = _.contains(Consts.STORAGES.resources.controllers, accessInfo['model']);
+                this.portsExist = _.contains(Consts.STORAGES.resources.ports, accessInfo['model']);
+                this.disksExist = _.contains(Consts.STORAGES.resources.disks, accessInfo['model']);
+                this.qtreesExist = _.contains(Consts.STORAGES.resources.qtrees, accessInfo['model']);
+                this.filesystemsExist = _.contains(Consts.STORAGES.resources.filesystems, accessInfo['model']);
+                this.sharesExist = _.contains(Consts.STORAGES.resources.shares, accessInfo['model']);
+                storageDevice['capacity'] = {};
+                let percentUsage = Math.ceil((storageDevice['used_capacity']/storageDevice['total_capacity']) * 100);
+                storageDevice['capacity'].used = Utils.formatBytes(storageDevice['used_capacity']);
+                storageDevice['capacity'].free = Utils.formatBytes(storageDevice['free_capacity']);
+                storageDevice['capacity'].total = Utils.formatBytes(storageDevice['total_capacity']);
+                storageDevice['capacity'].raw = Utils.formatBytes(storageDevice['raw_capacity']);
+                storageDevice['capacity'].subscribed = Utils.formatBytes(storageDevice['subscribed_capacity']);
+                let system_used = Math.ceil((storageDevice['raw_capacity'] - storageDevice['total_capacity']));
+                storageDevice['system_used_capacity'] = system_used;
+                storageDevice['capacity'].system_used = Utils.formatBytes(storageDevice['system_used_capacity']) ;
+                storageDevice['capacity'].usage = percentUsage;
 
-            this.selectedStorage = storageDevice;
+                this.selectedStorage = storageDevice;
+            },(error)=>{
+    
+            });
+            
         }, (error)=>{
             console.log("Something went wrong. Could not fetch storage", error);
         })

--- a/src/app/business/delfin/storage-details/storage-details.module.ts
+++ b/src/app/business/delfin/storage-details/storage-details.module.ts
@@ -9,6 +9,9 @@ import { StoragePoolsComponent } from '../storage-pools/storage-pools.component'
 import { ControllersComponent } from '../controllers/controllers.component';
 import { PortsComponent } from '../ports/ports.component';
 import { DisksComponent } from '../disks/disks.component';
+import { QtreesComponent } from '../qtrees/qtrees.component';
+import { FilesystemsComponent } from '../filesystems/filesystems.component';
+import { SharesComponent } from '../shares/shares.component';
 import { HttpService } from '../../../shared/api';
 import { ProfileService } from '../../profile/profile.service';
 import { AvailabilityZonesService } from '../../resource/resource.service';
@@ -47,7 +50,17 @@ let routers = [{
     TooltipModule,
     ProgressBarModule
   ],
-  declarations: [ StorageDetailsComponent, StorageVolumesComponent, StoragePoolsComponent, ControllersComponent, PortsComponent, DisksComponent, SafePipe  ],
+  declarations: [ 
+    StorageDetailsComponent, 
+    StorageVolumesComponent, 
+    StoragePoolsComponent, 
+    ControllersComponent, 
+    PortsComponent, 
+    DisksComponent, 
+    QtreesComponent, 
+    FilesystemsComponent,
+    SharesComponent,
+    SafePipe  ],
   providers: [
     HttpService,
     ProfileService,

--- a/src/app/business/delfin/storages/storages.component.html
+++ b/src/app/business/delfin/storages/storages.component.html
@@ -7,7 +7,7 @@
     <div class="table-toolbar">
         <div class="left">
             <button class="ui-button-secondary" pButton type="button" label="Register" [routerLink]="['/registerStorage']"></button>
-            <button [disabled]="!allStorages.length" pButton type="button" (click)="syncAllStorageDevices()" icon="fa-exchange" label="Sync All Devices"></button>
+            <button [disabled]="allStorages && !allStorages.length" pButton type="button" (click)="syncAllStorageDevices()" icon="fa-exchange" label="Sync All Devices"></button>
             <button *ngIf="showListView" pButton type="button" label="{{i18n.keyID['sds_block_volume_delete']}}" [disabled]="selectedStorages.length == 0" (click)="batchDeleteStorages(selectedStorages)"></button></div>
         <div class="right">
             <div [ngStyle]="{'visibility': showListView ? 'visible' : 'hidden'}" class="ui-inputsearch">
@@ -28,7 +28,7 @@
                         <div class="ui-g-row summary-card-header-container" >
                             <div class="ui-g-6 left-items" style="padding-left: 0.2rem;">
                                 <div class="ui-card-title">Storage Arrays</div>
-                                <div class="ui-card-subtitle">Total Number of Arrays: {{allStorages.length}}</div>
+                                <div class="ui-card-subtitle">Total Number of Arrays: {{allStorages && allStorages.length ? allStorages.length : 0}}</div>
                             </div>
                             <div class="ui-g-offset-4 ui-g-2">
                                 <a  (click)="toggleView()">Show all devices</a>
@@ -45,26 +45,35 @@
                                     <a [routerLink]="['/storageDetails/' + node.details.id]" (contextmenu)="deviceNodeMenu($event, node, deviceOverviewPanel)"  (mouseenter)="showOverview($event, node, deviceOverviewPanel)" (mouseleave)="deviceOverviewPanel.hide()">{{node.label}}</a>
                                     <i *ngIf="node.details.sync_status=='SYNCING'" title="Device is syncing" class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
                                 </ng-template>
-                                <ng-template #volumeParentTreeItem let-node pTemplate="volParent">
+                                <ng-template *ngIf="poolsExist" #poolParentTreeItem let-node pTemplate="poolParent">
                                     <a (mouseenter)="showOverview($event, node, parentOverviewPanel)" (mouseleave)="parentOverviewPanel.hide()">{{node.label}}</a>
                                 </ng-template>
-                                <ng-template #poolParentTreeItem let-node pTemplate="poolParent">
+                                <ng-template *ngIf="volumesExist" #volumeParentTreeItem let-node pTemplate="volParent">
                                     <a (mouseenter)="showOverview($event, node, parentOverviewPanel)" (mouseleave)="parentOverviewPanel.hide()">{{node.label}}</a>
                                 </ng-template>
-                                <ng-template #controllerParentTreeItem let-node pTemplate="controllerParent">
+                                <ng-template *ngIf="controllersExist" #controllerParentTreeItem let-node pTemplate="controllerParent">
                                     {{node.label}}
                                 </ng-template>
-                                <ng-template #portParentTreeItem let-node pTemplate="portParent">
+                                <ng-template *ngIf="portsExist" #portParentTreeItem let-node pTemplate="portParent">
                                     {{node.label}}
                                 </ng-template>
-                                <ng-template #diskParentTreeItem let-node pTemplate="diskParent">
+                                <ng-template *ngIf="disksExist" #diskParentTreeItem let-node pTemplate="diskParent">
                                     {{node.label}}
                                 </ng-template>
-                                <ng-template #volumeTreeItem let-node pTemplate="volNode">
-                                    <a (mouseenter)="showOverview($event, node, volumeOverviewPanel)" (mouseleave)="volumeOverviewPanel.hide()">{{node.label}}</a>
+                                <ng-template *ngIf="qtreesExist" #qtreeParentTreeItem let-node pTemplate="qtreeParent">
+                                    {{node.label}}
+                                </ng-template>
+                                <ng-template *ngIf="filesystemsExist" #filesystemParentTreeItem let-node pTemplate="filesystemParent">
+                                    <a (mouseenter)="showOverview($event, node, parentOverviewPanel)" (mouseleave)="parentOverviewPanel.hide()">{{node.label}}</a>
+                                </ng-template>
+                                <ng-template *ngIf="sharesExist" #shareParentTreeItem let-node pTemplate="shareParent">
+                                    {{node.label}}
                                 </ng-template>
                                 <ng-template #poolTreeItem let-node pTemplate="poolNode">
                                     <a (mouseenter)="showOverview($event, node, poolOverviewPanel)" (mouseleave)="poolOverviewPanel.hide()">{{node.label}}</a>
+                                </ng-template>
+                                <ng-template #volumeTreeItem let-node pTemplate="volNode">
+                                    <a (mouseenter)="showOverview($event, node, volumeOverviewPanel)" (mouseleave)="volumeOverviewPanel.hide()">{{node.label}}</a>
                                 </ng-template>
                                 <ng-template #controllerTreeItem let-node pTemplate="controllerNode">
                                     <a (mouseenter)="showOverview($event, node, controllerOverviewPanel)" (mouseleave)="controllerOverviewPanel.hide()">{{node.label}}</a>
@@ -74,6 +83,15 @@
                                 </ng-template>
                                 <ng-template #diskTreeItem let-node pTemplate="diskNode">
                                     <a (mouseenter)="showOverview($event, node, diskOverviewPanel)" (mouseleave)="diskOverviewPanel.hide()">{{node.label}}</a>
+                                </ng-template>
+                                <ng-template #qtreeTreeItem let-node pTemplate="qtreeNode">
+                                    <a (mouseenter)="showOverview($event, node, qtreeOverviewPanel)" (mouseleave)="qtreeOverviewPanel.hide()">{{node.label}}</a>
+                                </ng-template>
+                                <ng-template #filesystemTreeItem let-node pTemplate="filesystemNode">
+                                    <a (mouseenter)="showOverview($event, node, filesystemOverviewPanel)" (mouseleave)="filesystemOverviewPanel.hide()">{{node.label}}</a>
+                                </ng-template>
+                                <ng-template #shareTreeItem let-node pTemplate="shareNode">
+                                    <a (mouseenter)="showOverview($event, node, shareOverviewPanel)" (mouseleave)="shareOverviewPanel.hide()">{{node.label}}</a>
                                 </ng-template>
                             </p-tree>
                             <p-contextMenu #cm appendTo="body" [model]="contextMenuItems"></p-contextMenu>
@@ -176,7 +194,7 @@
                                         'capacity-usage-full' : device.capacity.usage > 95 }" [value]="device.capacity.usage" unit="% used"></p-progressBar>
                                 </div>
                             </div>
-                            <div *ngIf="!allStorages.length" class="no-records-found">
+                            <div *ngIf="allStorages && !allStorages.length" class="no-records-found">
                                 <span>No records found.</span>
                             </div>
                         </p-scrollPanel>
@@ -225,7 +243,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <div *ngIf="!allStorages.length" class="no-records-found">
+                            <div *ngIf="allStorages && !allStorages.length" class="no-records-found">
                                 <span>No records found.</span>
                             </div>
                         </p-scrollPanel>
@@ -243,7 +261,7 @@
     <div *ngIf="showListView">
         <div id="storage-devices-table" class="ui-g">
             <p-card  styleClass="ui-card-shadow">
-                <p-dataTable [value]="allStorages" [globalFilter]="searchAll" [lazy]="false" [(selection)]="selectedStorages" [expandableRows]="true" [showHeaderCheckbox]="true" [rows]="10" [paginator]="true" [pageLinks]="3" [rowsPerPageOptions]="[10,20,50,100]" #st>
+                <p-dataTable [value]="allStorages ? allStorages : []" [globalFilter]="searchAll" [lazy]="false" [(selection)]="selectedStorages" [expandableRows]="true" [showHeaderCheckbox]="true" [rows]="10" [paginator]="true" [pageLinks]="3" [rowsPerPageOptions]="[10,20,50,100]" #st>
                     <p-column expander="true" styleClass="col-icon" [style]="{'width': '3%'}"></p-column>
                     <p-column selectionMode="multiple" [style]="{'width': '3%'}"></p-column>
                     <p-column field="name" header="Name" [style]="{'width': '15%'}" [sortable]="true">
@@ -886,7 +904,9 @@
     <div class="ui-g overview-item">
         <div class="ui-g-6">
             <span class="overview-item-label">
-                Number of {{parentOverview && parentOverview.type=='volParent' ? 'Volumes' : 'Pools'}} 
+                Number of <span *ngIf="parentOverview && parentOverview.type=='volParent'">Volumes</span>
+                <span *ngIf="parentOverview && parentOverview.type=='poolParent'">Pools</span>
+                <span *ngIf="parentOverview && parentOverview.type=='filesystemParent'">Filesystem</span>
             </span>
         </div>
         <div class="ui-g-4 ui-g-offset-2">
@@ -1210,6 +1230,130 @@
             <span>
                 {{ diskOverview && diskOverview.details.health_score}}
             </span>
+        </div>
+    </div>
+</p-overlayPanel>
+
+<p-overlayPanel styleClass="overview-panel" #qtreeOverviewPanel>
+    <div class="ui-g overview-title">
+        <h4>{{qtreeOverview && qtreeOverview.details.name}}</h4>
+    </div>
+    <div class="ui-g ui-g-nopad overview-item" >
+        <div class="ui-g-6">
+            <span class="overview-item-label">Status: </span>
+        </div>
+        <div *ngIf="qtreeOverview" class="ui-g-6">
+            <span class="storage-status-icon" [ngClass]="{normal:  qtreeOverview && qtreeOverview.details.status =='normal', abnormal: qtreeOverview && qtreeOverview.details.status =='abnormal' || qtreeOverview.details.status =='unknown'}"><i class="fa fa-circle"></i></span>
+            <span *ngIf="qtreeOverview && qtreeOverview.details.status=='normal'">Normal</span>
+            <span *ngIf=" qtreeOverview && qtreeOverview.details.status=='abnormal' || qtreeOverview.details.status=='unknown'">Unknown</span>
+            <span *ngIf=" qtreeOverview && qtreeOverview.details.status=='offline'">Offline</span>
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            Security Mode
+        </div>
+        <div class="ui-g-6">
+            {{ qtreeOverview && qtreeOverview.details.security_mode}}
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            Path
+        </div>
+        <div class="ui-g-6">
+            {{qtreeOverview && qtreeOverview.details.path}}
+        </div>
+    </div>
+</p-overlayPanel>
+<p-overlayPanel styleClass="overview-panel" #filesystemOverviewPanel>
+    <div class="ui-g overview-title">
+        <h4>{{filesystemOverview && filesystemOverview.details.name}}</h4>
+    </div>
+    <div class="ui-g ui-g-nopad overview-item" >
+        <div class="ui-g-6">
+            <span class="overview-item-label">Status: </span>
+        </div>
+        <div class="ui-g-6">
+            <span class="storage-status-icon" [ngClass]="{normal:  filesystemOverview && filesystemOverview.details.status =='normal', abnormal: filesystemOverview && filesystemOverview.details.status =='faulty'}"><i class="fa fa-circle"></i></span>
+            <span *ngIf="filesystemOverview && filesystemOverview.details.status=='normal'">Normal</span>
+            <span *ngIf=" filesystemOverview && filesystemOverview.details.status=='faulty'">Faulty</span>
+            <span *ngIf=" filesystemOverview && filesystemOverview.details.status=='offline'">Offline</span>
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            <span class="overview-item-label">
+              Storage ID  
+            </span>
+        </div>
+        <div class="ui-g-6">
+            <span>
+                {{ filesystemOverview && filesystemOverview.details.storage_id}}
+            </span>
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            Type
+        </div>
+        <div class="ui-g-6">
+            {{ filesystemOverview && filesystemOverview.details.type}}
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            Compressed
+        </div>
+        <div class="ui-g-6">
+            {{ filesystemOverview && filesystemOverview.details.compressed ? "Yes" : "No"}}
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            Deduplicated
+        </div>
+        <div class="ui-g-6">
+            {{ filesystemOverview && filesystemOverview.details.deduplicated ? "Yes" : "No"}}
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            <span class="overview-item-label">
+              Security Mode
+            </span>
+        </div>
+        <div class="ui-g-6">
+            <span>
+                {{ filesystemOverview && filesystemOverview.details.security_mode}}
+            </span>
+        </div>
+    </div>
+    <hr />
+    <div class="ui-g overview-item">
+        <div class="ui-g-12">
+            <span class="overview-item-label">Usable Capacity Summary</span>
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div *ngIf="filesystemOverview && filesystemOverview.details.capacity" class="capacity-stats-bar">
+            <table class="capacity-table" *ngIf="filesystemOverview && filesystemOverview.details.capacity">
+                <thead>
+                    <th class="capacity-header">Free</th>
+                    <th class="capacity-header">Used</th>
+                    <th class="capacity-header">Total</th>
+                </thead>
+                <tbody>
+                    <td class="capacity-field"><span class="free-storage">{{filesystemOverview.details.capacity && filesystemOverview.details.capacity.free ? filesystemOverview.details.capacity.free : '-'}} </span></td>
+                    <td class="capacity-field"><span class="used-storage">{{filesystemOverview.details.capacity && filesystemOverview.details.capacity.used ? filesystemOverview.details.capacity.used : '-'}} </span></td>
+                    <td class="capacity-field"><span class="total-storage">{{filesystemOverview.details.capacity && filesystemOverview.details.capacity.total ? filesystemOverview.details.capacity.total : '-'}} </span></td>
+                </tbody>
+            </table>
+            <div class="storage-usage-bar" >
+                <p-progressBar [ngClass]="{'capacity-usage-zero': filesystemOverview.details.capacity.usage == 0, 'capacity-usage-normal': filesystemOverview.details.capacity.usage > 0 && filesystemOverview.details.capacity.usage < 75, 
+                    'capacity-usage-warning': filesystemOverview.details.capacity.usage > 75 && filesystemOverview.details.capacity.usage < 95, 
+                    'capacity-usage-full' : filesystemOverview.details.capacity.usage > 95 }" [value]="filesystemOverview.details.capacity.usage" unit="% used"></p-progressBar>
+            </div>
         </div>
     </div>
 </p-overlayPanel>

--- a/src/app/business/delfin/storages/storages.component.ts
+++ b/src/app/business/delfin/storages/storages.component.ts
@@ -23,6 +23,7 @@ export class StoragesComponent implements OnInit {
     allArrays: TreeNode[];
     arrayTreeData: TreeNode[];
     allStorages: any = [];
+    allResolvedStorages: any = [];
     selectedStorages: any = [];
     selectedStorageId: any;
     selectStorage;
@@ -65,12 +66,23 @@ export class StoragesComponent implements OnInit {
     portOverview;
     diskOverview;
     parentOverview;
+    qtreeOverview;
+    filesystemOverview;
+    shareOverview;
     groupedByVendor;
     totalArrayRawCapacity: any;
     totalArrayUsableCapacity: any;
     totalArrayFreeCapacity: any;
     allActiveAlerts: any = [];
     scrollerData: any = [];
+    volumesExist: boolean = false;
+    poolsExist: boolean = false;
+    controllersExist: boolean = false;
+    portsExist: boolean = false;
+    disksExist: boolean = false;
+    qtreesExist: boolean = false;
+    filesystemsExist: boolean = false;
+    sharesExist: boolean = false;
     msgs: Message[];
 
     label = {
@@ -174,11 +186,16 @@ export class StoragesComponent implements OnInit {
                     this.msgs.push(JSON.parse(message));
                 }
             });
+            // Resolve the Storages before loading the page
+            this.ActivatedRoute.data.subscribe((res:Response) => {
+                let resolvedStorages = res['storages'];
+                this.allResolvedStorages = resolvedStorages;
+            });
     }
 
     ngOnInit() {
         this.loading = true;
-        this.getAllStorages();
+        this.onPageFirstLoad();
         this.getAllActiveAlerts();
         
         this.menuItems = [
@@ -319,6 +336,11 @@ export class StoragesComponent implements OnInit {
     toggleView(){
         this.showListView = this.showListView ? this.showListView : !this.showListView;
     }
+    onPageFirstLoad(){
+        this.allStorages = this.allResolvedStorages;
+        this.prepareTree(this.allStorages);
+        this.loading = false;
+    }
     
     getAllStorages(){
         this.allStorages = [];
@@ -342,56 +364,110 @@ export class StoragesComponent implements OnInit {
                 element['capacity'].system_used = Utils.formatBytes(element['system_used_capacity']) ;
                 element['capacity'].usage = percentUsage;
                 
-                element['volumes'] = [];
-                element['storagePools'] = [];
-                element['controllers'] = [];
-                element['ports'] = [];
-                element['disks'] = [];
                 let vols = [];
                 let pools = [];
                 let controllers = [];
                 let ports = [];
                 let disks = [];
+                let qtrees = [];
+                let filesystems = [];
+                let shares = [];
+                let accessInfo: any;
+                // Get the access info of the device to fetch the Delfin Driver model used
+                this.ds.getAccessinfoByStorageId(element['id']).subscribe((res)=>{                    
+                    accessInfo = res.json();
+                    element['delfin_model'] = accessInfo['model'];
+                    
+                    this.volumesExist = _.contains(Consts.STORAGES.resources.volumes, accessInfo['model']);
+                    this.poolsExist = _.contains(Consts.STORAGES.resources.pools, accessInfo['model']);
+                    this.controllersExist = _.contains(Consts.STORAGES.resources.controllers, accessInfo['model']);
+                    this.portsExist = _.contains(Consts.STORAGES.resources.ports, accessInfo['model']);
+                    this.disksExist = _.contains(Consts.STORAGES.resources.disks, accessInfo['model']);
+                    this.qtreesExist = _.contains(Consts.STORAGES.resources.qtrees, accessInfo['model']);
+                    this.filesystemsExist = _.contains(Consts.STORAGES.resources.filesystems, accessInfo['model']);
+                    this.sharesExist = _.contains(Consts.STORAGES.resources.shares, accessInfo['model']);
+                    if(this.volumesExist){
+                        // Get all the volumes associated with the Storage device
+                        this.ds.getAllVolumes(element['id']).subscribe((res)=>{
+                            vols = res.json().volumes;
+                            element['volumes'] = vols;
+                        }, (error)=>{
+                            console.log("Something went wrong. Could not fetch Volumes.", error)
+                        });
+                    }
 
-                // Get all the Storage pools associated with the Storage device
-                this.ds.getAllStoragePools(element['id']).subscribe((res)=>{
-                    pools = res.json().storage_pools;
-                    element['storagePools'] = pools;
+                    if(this.poolsExist){
+                        // Get all the Storage pools associated with the Storage device 
+                        this.ds.getAllStoragePools(element['id']).subscribe((res)=>{
+                            pools = res.json().storage_pools;
+                            element['storagePools'] = pools;
+                        }, (error)=>{
+                            console.log("Something went wrong. Could not fetch Storage Pools.", error)
+                        });
+                    }
+                    if(this.controllersExist){
+                        // Get all the Controllers associated with the Storage device
+                        this.ds.getAllControllers(element['id']).subscribe((res)=>{
+                            controllers = res.json().controllers;
+                            element['controllers'] = controllers;
+                        }, (error)=>{
+                            console.log("Something went wrong. Could not fetch Controllers.", error)
+                        });
+                    }
+                    if(this.portsExist){
+                        
+                        // Get all the Ports associated with the Storage device
+                        this.ds.getAllPorts(element['id']).subscribe((res)=>{
+                            console.log("Ports fetched")
+                            ports = res.json().ports;
+                            element['ports'] = ports;
+                        }, (error)=>{
+                            console.log("Something went wrong. Could not fetch Ports.", error)
+                        });
+                    } else{
+                        element['portsExist'] = this.portsExist;
+                    }
+                    if(this.disksExist){
+                        // Get all the Disks associated with the Storage device
+                        this.ds.getAllDisks(element['id']).subscribe((res)=>{
+                            disks = res.json().disks;
+                            element['disks'] = disks;
+                        }, (error)=>{
+                            console.log("Something went wrong. Could not fetch Disks.", error)
+                        });
+                    }
+                    if(this.qtreesExist){
+                        // Get all the Qtrees associated with the Storage device
+                        this.ds.getAllQtrees(element['id']).subscribe((res)=>{
+                            qtrees = res.json().qtrees;
+                            element['qtrees'] = qtrees;
+                        }, (error)=>{
+                            console.log("Something went wrong. Could not fetch Qtrees.", error)
+                        });
+                    }
+                    if(this.filesystemsExist){
+                        // Get all the Filesystems associated with the Storage device
+                        this.ds.getAllFilesystems(element['id']).subscribe((res)=>{
+                            filesystems = res.json().filesystems;
+                            element['filesystems'] = filesystems;
+                        }, (error)=>{
+                            console.log("Something went wrong. Could not fetch Filesystems.", error)
+                        });
+                    }
+                    if(this.sharesExist){
+                        // Get all the Shares associated with the Storage device
+                        this.ds.getAllShares(element['id']).subscribe((res)=>{
+                            shares = res.json().shares;
+                            element['shares'] = shares;
+                        }, (error)=>{
+                            console.log("Something went wrong. Could not fetch Shares.", error)
+                        });
+                    } else{
+                        element['sharesExist'] = this.sharesExist;
+                    }
                 }, (error)=>{
-                    console.log("Something went wrong. Could not fetch Storage Pools.", error)
-                });
-
-                // Get all the volumes associated with the Storage device
-                this.ds.getAllVolumes(element['id']).subscribe((res)=>{
-                    vols = res.json().volumes;
-                    element['volumes'] = vols;
-                }, (error)=>{
-                    console.log("Something went wrong. Could not fetch Volumes.", error)
-                });
-
-                // Get all the Controllers associated with the Storage device
-                this.ds.getAllControllers(element['id']).subscribe((res)=>{
-                    controllers = res.json().controllers;
-                    element['controllers'] = controllers;
-                }, (error)=>{
-                    console.log("Something went wrong. Could not fetch Controllers.", error)
-                });
-
-                // Get all the Ports associated with the Storage device
-                this.ds.getAllPorts(element['id']).subscribe((res)=>{
-                    ports = res.json().ports;
-                    element['ports'] = ports;
-                }, (error)=>{
-                    console.log("Something went wrong. Could not fetch Ports.", error)
-                });
-                
-                // Get all the Disks associated with the Storage device
-                this.ds.getAllDisks(element['id']).subscribe((res)=>{
-                    disks = res.json().disks;
-                    element['disks'] = disks;
-                }, (error)=>{
-                    console.log("Something went wrong. Could not fetch Disks.", error)
-                });
+                    console.log("Something went wrong. Could not fetch Access info.", error)
+                })
 
                 let capData = {
                     labels: ['Used','Free'],
@@ -421,6 +497,9 @@ export class StoragesComponent implements OnInit {
                 element['controllers'] = controllers;
                 element['ports'] = ports;
                 element['disks'] = disks;
+                element['qtrees'] = qtrees;
+                element['filesystems'] = filesystems;
+                element['shares'] = shares;
             });
 
             // Invoke prepareTree() to prepare the tree structure for the widget
@@ -445,7 +524,7 @@ export class StoragesComponent implements OnInit {
         return group;
     }
 
-    // This method
+    // This method prepares the array for the tree view
     prepareTree(storages){
         let self = this;
         let treeData = [];
@@ -517,35 +596,6 @@ export class StoragesComponent implements OnInit {
                             
                             modelGroupNode.details.totalSystemUsedCapacity = Math.ceil((storageDevice['raw_capacity'] - storageDevice['total_capacity']));
                             
-                            // Create the Volume parent Node
-                            
-                            let parentVolNode = {};
-                            if(storageDevice['volumes'] ){
-                                parentVolNode = {
-                                    label : "Volumes",
-                                    collapsedIcon: 'fa-database',
-                                    expandedIcon: 'fa-database',
-                                    type: 'volParent',
-                                    styleClass: 'volume-parent-node',
-                                    leaf: false,
-                                    details: {
-                                        totalUsableCapacity: 0,
-                                        totalFreeCapacity: 0,
-                                        totalUsedCapacity: 0,
-                                        totalUsagePercent: 0,
-                                        totalRawCapacity: 0,
-                                        totalSubscribedCapacity: 0,
-                                        totalSystemUsedCapacity: 0,
-                                        displayTotal: null,
-                                        displayFree: null,
-                                        displayUsed: null,
-                                        displayRaw: null,
-                                        displaySubscribed: null,
-                                        displaySystemUsed: null
-                                    }
-                                }
-                                modelTreeNode['children'].push(parentVolNode);
-                            }
                             // Create the Storage Pool parent Node
                             let parentPoolNode = {};
                             if(storageDevice['storagePools']){
@@ -573,6 +623,35 @@ export class StoragesComponent implements OnInit {
                                     }
                                 }
                                 modelTreeNode['children'].push(parentPoolNode);
+                            }
+
+                            // Create the Volume parent Node
+                            let parentVolNode = {};
+                            if(storageDevice['volumes'] ){
+                                parentVolNode = {
+                                    label : "Volumes",
+                                    collapsedIcon: 'fa-database',
+                                    expandedIcon: 'fa-database',
+                                    type: 'volParent',
+                                    styleClass: 'volume-parent-node',
+                                    leaf: false,
+                                    details: {
+                                        totalUsableCapacity: 0,
+                                        totalFreeCapacity: 0,
+                                        totalUsedCapacity: 0,
+                                        totalUsagePercent: 0,
+                                        totalRawCapacity: 0,
+                                        totalSubscribedCapacity: 0,
+                                        totalSystemUsedCapacity: 0,
+                                        displayTotal: null,
+                                        displayFree: null,
+                                        displayUsed: null,
+                                        displayRaw: null,
+                                        displaySubscribed: null,
+                                        displaySystemUsed: null
+                                    }
+                                }
+                                modelTreeNode['children'].push(parentVolNode);
                             }
 
                             // Create the Controller parent Node
@@ -603,7 +682,7 @@ export class StoragesComponent implements OnInit {
                                 modelTreeNode['children'].push(parentPortNode);
                             }
 
-                            // Create the Port parent Node
+                            // Create the Disk parent Node
                             let parentDiskNode = {};
                             if(storageDevice['disks']){
                                 parentDiskNode = {
@@ -615,6 +694,57 @@ export class StoragesComponent implements OnInit {
                                     leaf: false
                                 }
                                 modelTreeNode['children'].push(parentDiskNode);
+                            }
+
+                            // Create the Qtree parent Node
+                            let parentQtreeNode = {};
+                            if(storageDevice['qtrees']){
+                                parentQtreeNode = {
+                                    label : "Qtrees",
+                                    collapsedIcon: 'fa-pie-chart',
+                                    expandedIcon: 'fa-pie-chart',
+                                    styleClass: 'qtree-parent-node',
+                                    type: 'qtreeParent',
+                                    leaf: false
+                                }
+                                modelTreeNode['children'].push(parentQtreeNode);
+                            }
+
+                            // Create the Filesystems parent Node
+                            let parentFilesystemNode = {};
+                            if(storageDevice['filesystems']){
+                                parentFilesystemNode = {
+                                    label : "Filesystems",
+                                    collapsedIcon: 'fa-files-o',
+                                    expandedIcon: 'fa-files-o',
+                                    styleClass: 'filesystem-parent-node',
+                                    type: 'filesystemParent',
+                                    leaf: false,
+                                    details: {
+                                        totalUsableCapacity: 0,
+                                        totalFreeCapacity: 0,
+                                        totalUsedCapacity: 0,
+                                        totalUsagePercent: 0,
+                                        displayTotal: null,
+                                        displayFree: null,
+                                        displayUsed: null,
+                                    }
+                                }
+                                modelTreeNode['children'].push(parentFilesystemNode);
+                            }
+
+                            // Create the Shares parent Node
+                            let parentShareNode = {};
+                            if(storageDevice['shares']){
+                                parentShareNode = {
+                                    label : "Shares",
+                                    collapsedIcon: 'fa-share-square-o',
+                                    expandedIcon: 'fa-share-square-o',
+                                    styleClass: 'share-parent-node',
+                                    type: 'shareParent',
+                                    leaf: false
+                                }
+                                modelTreeNode['children'].push(parentShareNode);
                             }
 
                             // Push each storage device as a child of the model node
@@ -637,7 +767,6 @@ export class StoragesComponent implements OnInit {
             treeData.push(vendorTreeNode);
         })
         this.arrayTreeData = treeData;
-        
     }
 
     // Invoked on expanding a parent node in the tree above
@@ -645,153 +774,256 @@ export class StoragesComponent implements OnInit {
     loadNode(event){
         let self =this;
         //Check if the expanded node is a device
-
         if(event.node.type == 'device'){
             let device = event.node;
 
             //check each child if it is a Volume parent or Pool Parent
             _.each(device['children'], function(devChild){
-                if(devChild['type']=='volParent'){
-                    devChild['children'] = [];
+                switch (devChild['type']) {
+                    case 'poolParent':
+                        devChild['children'] = [];
 
-                    // If Volume parent then iterate through all volumes and calculate the capacities and stats for 
-                    // each volume parent and volume node
+                        // If pool parent then iterate through all storage pools and calculate the capacities and stats for 
+                        // each pool parent and pool node
 
-                    if(device['details'].volumes && device['details'].volumes.length){
-                        let volChildNode ={};
-                        _.each(device['details'].volumes, function(volItem){
-                            //Calculate the capacities for the Volume
-                            volItem['capacity'] = {};
-                            let percentUsage = Math.ceil((volItem['used_capacity']/volItem['total_capacity']) * 100);
-                            volItem['capacity'].used = Utils.formatBytes(volItem['used_capacity']);
-                            volItem['capacity'].free = Utils.formatBytes(volItem['free_capacity']);
-                            volItem['capacity'].total = Utils.formatBytes(volItem['total_capacity']);
-                            volItem['capacity'].system_used = Utils.formatBytes(volItem['system_used_capacity']) ;
-                            volItem['capacity'].usage = percentUsage;
+                        if(device['details'].storagePools && device['details'].storagePools.length){
+                            let poolChildNode ={};
+                            _.each(device['details'].storagePools, function(poolItem){
+                                //Calculate the capacities for the Volume
+                                poolItem['capacity'] = {};
+                                let percentUsage = Math.ceil((poolItem['used_capacity']/poolItem['total_capacity']) * 100);
+                                poolItem['capacity'].used = Utils.formatBytes(poolItem['used_capacity']);
+                                poolItem['capacity'].free = Utils.formatBytes(poolItem['free_capacity']);
+                                poolItem['capacity'].total = Utils.formatBytes(poolItem['total_capacity']);
+                                poolItem['capacity'].usage = percentUsage;
 
-                            //Create the capacity stats for each volume group by summing together the capacity of each device
-                            devChild['details'].totalUsableCapacity+=volItem['total_capacity'];
-                            devChild['details'].totalUsedCapacity+=volItem['used_capacity'];
-                            devChild['details'].totalFreeCapacity+=volItem['free_capacity'];
+                                //Create the capacity stats for each pool group by summing together the capacity of each device
+                                devChild['details'].totalUsableCapacity+=poolItem['total_capacity'];
+                                devChild['details'].totalUsedCapacity+=poolItem['used_capacity'];
+                                devChild['details'].totalFreeCapacity+=poolItem['free_capacity'];
+                                
+                                poolChildNode = {
+                                    label : poolItem['name'],
+                                    collapsedIcon: 'fa-cubes',
+                                    expandedIcon: 'fa-cubes',
+                                    styleClass: 'pool-node',
+                                    type: 'poolNode',
+                                    details: poolItem,
+                                }
+                                devChild['children'].push(poolChildNode);
+                            })
                             
-                            volChildNode = {
-                                label : volItem['name'],
-                                collapsedIcon: 'fa-database',
-                                expandedIcon: 'fa-database',
-                                styleClass: 'volume-node',
-                                type: 'volNode',
-                                details: volItem,
+                            //Populate the display values
+                            devChild['details'].totalUsagePercent = Math.ceil((devChild['details'].totalUsedCapacity/devChild['details'].totalUsableCapacity) * 100);
+                            devChild['details'].displayTotal = Utils.formatBytes(devChild['details'].totalUsableCapacity);
+                            devChild['details'].displayFree = Utils.formatBytes(devChild['details'].totalFreeCapacity);
+                            devChild['details'].displayUsed = Utils.formatBytes(devChild['details'].totalUsedCapacity);
+                            devChild['label'] = "Storage Pools " + "(" + devChild['children'].length + ")";
+                        } else {
+                            devChild['label'] = "Storage Pools " + "(" + devChild['children'].length + ")";
+                        }
+                        break;
+                    case 'volParent':
+                        devChild['children'] = [];
+                        // If Volume parent then iterate through all volumes and calculate the capacities and stats for 
+                        // each volume parent and volume node
+                        if(device['details'].volumes && device['details'].volumes.length){
+                            let volChildNode ={};
+                            _.each(device['details'].volumes, function(volItem){
+                                //Calculate the capacities for the Volume
+                                volItem['capacity'] = {};
+                                let percentUsage = Math.ceil((volItem['used_capacity']/volItem['total_capacity']) * 100);
+                                volItem['capacity'].used = Utils.formatBytes(volItem['used_capacity']);
+                                volItem['capacity'].free = Utils.formatBytes(volItem['free_capacity']);
+                                volItem['capacity'].total = Utils.formatBytes(volItem['total_capacity']);
+                                volItem['capacity'].system_used = Utils.formatBytes(volItem['system_used_capacity']) ;
+                                volItem['capacity'].usage = percentUsage;
+
+                                //Create the capacity stats for each volume group by summing together the capacity of each device
+                                devChild['details'].totalUsableCapacity+=volItem['total_capacity'];
+                                devChild['details'].totalUsedCapacity+=volItem['used_capacity'];
+                                devChild['details'].totalFreeCapacity+=volItem['free_capacity'];
+                                
+                                volChildNode = {
+                                    label : volItem['name'],
+                                    collapsedIcon: 'fa-database',
+                                    expandedIcon: 'fa-database',
+                                    styleClass: 'volume-node',
+                                    type: 'volNode',
+                                    details: volItem,
+                                }
+                                devChild['children'].push(volChildNode);
+                            })
+
+                            //Populate the display values
+                            devChild['details'].totalUsagePercent = Math.ceil((devChild['details'].totalUsedCapacity/devChild['details'].totalUsableCapacity) * 100);
+                            devChild['details'].displayTotal = Utils.formatBytes(devChild['details'].totalUsableCapacity);
+                            devChild['details'].displayFree = Utils.formatBytes(devChild['details'].totalFreeCapacity);
+                            devChild['details'].displayUsed = Utils.formatBytes(devChild['details'].totalUsedCapacity);
+                            devChild['label'] = "Volumes " + "(" + devChild['children'].length + ")";
+                        } else{
+                            devChild['label'] = "Volumes " + "(" + devChild['children'].length + ")";
+                        }
+                        break;
+                    
+                    case 'controllerParent':
+                        devChild['children']=[];
+
+                        if(device['details'].controllers && device['details'].controllers.length){
+                            let controllerChildNode = {};
+                            _.each(device['details'].controllers, function(controllerItem){
+
+                                controllerItem['displayMemory'] = Utils.formatBytes(controllerItem['memory_size']);
+                                controllerChildNode = {
+                                    label: controllerItem['name'],
+                                    collapsedIcon: 'fa-microchip',
+                                    expandedIcon: 'fa-microchip',
+                                    styleClass: 'controller-node',
+                                    type: 'controllerNode',
+                                    details: controllerItem
+                                }
+                                devChild['children'].push(controllerChildNode);
+                            });
+                            devChild['label'] = "Controllers " + "(" + devChild['children'].length + ")";
+                        } else {
+                            devChild['label'] = "Controllers " + "(" + devChild['children'].length + ")";
+                        }
+                        break;
+                    case 'portParent':
+                        devChild['children']=[];
+
+                        if(device['details'].ports && device['details'].ports.length){
+                            let portChildNode = {};
+                            _.each(device['details'].ports, function(portItem){
+
+                                portItem['displayMemory'] = Utils.formatBytes(portItem['memory_size']);
+                                portChildNode = {
+                                    label: portItem['name'],
+                                    collapsedIcon: 'fa-plug',
+                                    expandedIcon: 'fa-plug',
+                                    styleClass: 'port-node',
+                                    type: 'portNode',
+                                    details: portItem
+                                }
+                                devChild['children'].push(portChildNode);
+                            });
+                            devChild['label'] = "Ports " + "(" + devChild['children'].length + ")";
+                        } else{
+                            devChild['label'] = "Ports " + "(" + devChild['children'].length + ")";
+                        }
+                        break;
+                    case 'diskParent':
+                        devChild['children']=[];
+
+                        if(device['details'].disks && device['details'].disks.length){
+                            let diskChildNode = {};
+                            _.each(device['details'].disks, function(diskItem){
+
+                                diskItem['displayCapacity'] = Utils.formatBytes(diskItem['capacity']);
+                                diskChildNode = {
+                                    label: diskItem['name'],
+                                    collapsedIcon: 'fa-floppy-o',
+                                    expandedIcon: 'fa-floppy-o',
+                                    styleClass: 'disk-node',
+                                    type: 'diskNode',
+                                    details: diskItem
+                                }
+                                devChild['children'].push(diskChildNode);
+                            });
+                            devChild['label'] = "Disks " + "(" + devChild['children'].length + ")";
+                        } else {
+                            devChild['label'] = "Disks " + "(" + devChild['children'].length + ")";
+                        }
+                        break;
+                        case 'qtreeParent':
+                            devChild['children']=[];
+
+                            if(device['details'].qtrees && device['details'].qtrees.length){
+                                let qtreeChildNode = {};
+                                _.each(device['details'].qtrees, function(qtreeItem){
+
+                                    qtreeChildNode = {
+                                        label: qtreeItem['name'],
+                                        collapsedIcon: 'fa-pie-chart',
+                                        expandedIcon: 'fa-pie-chart',
+                                        styleClass: 'qtree-node',
+                                        type: 'qtreeNode',
+                                        details: qtreeItem
+                                    }
+                                    devChild['children'].push(qtreeChildNode);
+                                });
+                                devChild['label'] = "Qtrees " + "(" + devChild['children'].length + ")";
+                            } else {
+                                devChild['label'] = "Qtrees " + "(" + devChild['children'].length + ")";
                             }
-                            devChild['children'].push(volChildNode);
-                        })
-
-                        //Populate the display values
-                        devChild['details'].totalUsagePercent = Math.ceil((devChild['details'].totalUsedCapacity/devChild['details'].totalUsableCapacity) * 100);
-                        devChild['details'].displayTotal = Utils.formatBytes(devChild['details'].totalUsableCapacity);
-                        devChild['details'].displayFree = Utils.formatBytes(devChild['details'].totalFreeCapacity);
-                        devChild['details'].displayUsed = Utils.formatBytes(devChild['details'].totalUsedCapacity);
-                        devChild['label'] = "Volumes " + "(" + devChild['children'].length + ")";
-                    }
-                } else if(devChild['type']=='poolParent'){
-                    devChild['children'] = [];
-
-                    // If pool parent then iterate through all storage pools and calculate the capacities and stats for 
-                    // each pool parent and pool node
-
-                    if(device['details'].storagePools && device['details'].storagePools.length){
-                        let poolChildNode ={};
-                        _.each(device['details'].storagePools, function(poolItem){
-                            //Calculate the capacities for the Volume
-                            poolItem['capacity'] = {};
-                            let percentUsage = Math.ceil((poolItem['used_capacity']/poolItem['total_capacity']) * 100);
-                            poolItem['capacity'].used = Utils.formatBytes(poolItem['used_capacity']);
-                            poolItem['capacity'].free = Utils.formatBytes(poolItem['free_capacity']);
-                            poolItem['capacity'].total = Utils.formatBytes(poolItem['total_capacity']);
-                            poolItem['capacity'].usage = percentUsage;
-
-                            //Create the capacity stats for each pool group by summing together the capacity of each device
-                            devChild['details'].totalUsableCapacity+=poolItem['total_capacity'];
-                            devChild['details'].totalUsedCapacity+=poolItem['used_capacity'];
-                            devChild['details'].totalFreeCapacity+=poolItem['free_capacity'];
-                            
-                            poolChildNode = {
-                                label : poolItem['name'],
-                                collapsedIcon: 'fa-cubes',
-                                expandedIcon: 'fa-cubes',
-                                styleClass: 'pool-node',
-                                type: 'poolNode',
-                                details: poolItem,
+                            break;
+                        case 'filesystemParent':
+                            devChild['children'] = [];
+    
+                            // If filesystem parent then iterate through all storage filesystems and calculate the capacities and stats for 
+                            // each filesystem parent and filesystem node
+    
+                            if(device['details'].filesystems && device['details'].filesystems.length){
+                                let filesystemChildNode ={};
+                                _.each(device['details'].filesystems, function(filesystemItem){
+                                    //Calculate the capacities for the Volume
+                                    filesystemItem['capacity'] = {};
+                                    let percentUsage = Math.ceil((filesystemItem['used_capacity']/filesystemItem['total_capacity']) * 100);
+                                    filesystemItem['capacity'].used = Utils.formatBytes(filesystemItem['used_capacity']);
+                                    filesystemItem['capacity'].free = Utils.formatBytes(filesystemItem['free_capacity']);
+                                    filesystemItem['capacity'].total = Utils.formatBytes(filesystemItem['total_capacity']);
+                                    filesystemItem['capacity'].usage = percentUsage;
+    
+                                    //Create the capacity stats for each filesystem group by summing together the capacity of each device
+                                    devChild['details'].totalUsableCapacity+=filesystemItem['total_capacity'];
+                                    devChild['details'].totalUsedCapacity+=filesystemItem['used_capacity'];
+                                    devChild['details'].totalFreeCapacity+=filesystemItem['free_capacity'];
+                                    
+                                    filesystemChildNode = {
+                                        label : filesystemItem['name'],
+                                        collapsedIcon: 'fa-files-o',
+                                        expandedIcon: 'fa-files-o',
+                                        styleClass: 'filesystem-node',
+                                        type: 'filesystemNode',
+                                        details: filesystemItem,
+                                    }
+                                    devChild['children'].push(filesystemChildNode);
+                                })
+                                
+                                //Populate the display values
+                                devChild['details'].totalUsagePercent = Math.ceil((devChild['details'].totalUsedCapacity/devChild['details'].totalUsableCapacity) * 100);
+                                devChild['details'].displayTotal = Utils.formatBytes(devChild['details'].totalUsableCapacity);
+                                devChild['details'].displayFree = Utils.formatBytes(devChild['details'].totalFreeCapacity);
+                                devChild['details'].displayUsed = Utils.formatBytes(devChild['details'].totalUsedCapacity);
+                                devChild['label'] = "Filesystems " + "(" + devChild['children'].length + ")";
+                            } else {
+                                devChild['label'] = "Filesystems " + "(" + devChild['children'].length + ")";
                             }
-                            devChild['children'].push(poolChildNode);
-                        })
-                        
-                        //Populate the display values
-                        devChild['details'].totalUsagePercent = Math.ceil((devChild['details'].totalUsedCapacity/devChild['details'].totalUsableCapacity) * 100);
-                        devChild['details'].displayTotal = Utils.formatBytes(devChild['details'].totalUsableCapacity);
-                        devChild['details'].displayFree = Utils.formatBytes(devChild['details'].totalFreeCapacity);
-                        devChild['details'].displayUsed = Utils.formatBytes(devChild['details'].totalUsedCapacity);
-                        devChild['label'] = "Storage Pools " + "(" + devChild['children'].length + ")";
-                    }
-                } else if(devChild['type']=='controllerParent'){
-                    devChild['children']=[];
+                            break;
+                        case 'shareParent':
+                            devChild['children']=[];
 
-                    if(device['details'].controllers && device['details'].controllers.length){
-                        let controllerChildNode = {};
-                        _.each(device['details'].controllers, function(controllerItem){
+                            if(device['details'].shares && device['details'].shares.length){
+                                let shareChildNode = {};
+                                _.each(device['details'].shares, function(shareItem){
 
-                            controllerItem['displayMemory'] = Utils.formatBytes(controllerItem['memory_size']);
-                            controllerChildNode = {
-                                label: controllerItem['name'],
-                                collapsedIcon: 'fa-microchip',
-                                expandedIcon: 'fa-microchip',
-                                styleClass: 'controller-node',
-                                type: 'controllerNode',
-                                details: controllerItem
+                                    shareChildNode = {
+                                        label: shareItem['name'],
+                                        collapsedIcon: 'fa-share-square-o',
+                                        expandedIcon: 'fa-share-square-o',
+                                        styleClass: 'share-node',
+                                        type: 'shareNode',
+                                        details: shareItem
+                                    }
+                                    devChild['children'].push(shareChildNode);
+                                });
+                                devChild['label'] = "Shares " + "(" + devChild['children'].length + ")";
+                            } else {
+                                devChild['label'] = "Shares " + "(" + devChild['children'].length + ")";
                             }
-                            devChild['children'].push(controllerChildNode);
-                        });
-                        devChild['label'] = "Controllers " + "(" + devChild['children'].length + ")";
-                    }
-                } else if(devChild['type']=='portParent'){
-                    devChild['children']=[];
-
-                    if(device['details'].ports && device['details'].ports.length){
-                        let portChildNode = {};
-                        _.each(device['details'].ports, function(portItem){
-
-                            portItem['displayMemory'] = Utils.formatBytes(portItem['memory_size']);
-                            portChildNode = {
-                                label: portItem['name'],
-                                collapsedIcon: 'fa-plug',
-                                expandedIcon: 'fa-plug',
-                                styleClass: 'port-node',
-                                type: 'portNode',
-                                details: portItem
-                            }
-                            devChild['children'].push(portChildNode);
-                        });
-                        devChild['label'] = "Ports " + "(" + devChild['children'].length + ")";
-                    }
-                } else if(devChild['type']=='diskParent'){
-                    devChild['children']=[];
-
-                    if(device['details'].disks && device['details'].disks.length){
-                        let diskChildNode = {};
-                        _.each(device['details'].disks, function(diskItem){
-
-                            diskItem['displayCapacity'] = Utils.formatBytes(diskItem['capacity']);
-                            diskChildNode = {
-                                label: diskItem['name'],
-                                collapsedIcon: 'fa-floppy-o',
-                                expandedIcon: 'fa-floppy-o',
-                                styleClass: 'port-node',
-                                type: 'diskNode',
-                                details: diskItem
-                            }
-                            devChild['children'].push(diskChildNode);
-                        });
-                        devChild['label'] = "Disks " + "(" + devChild['children'].length + ")";
-                    }
+                            break;
+                    default:
+                        break;
                 }
             })
         }
@@ -915,7 +1147,12 @@ export class StoragesComponent implements OnInit {
 
     //Show the overview panel when hovering on device in the tree.
     showOverview(event, node, overlaypanel: OverlayPanel){
-        let deviceOverlaypanel, modelOverlayPanel, volumeParentOverlayPanel, poolParentOverlayPanel, controllerOverlayPanel, portOverlayPanel, diskOverlayPanel, volumeOverlayPanel, poolOverlayPanel;
+        let deviceOverlaypanel, modelOverlayPanel, 
+            volumeParentOverlayPanel, poolParentOverlayPanel, filesystemParentOverlayPanel,
+            controllerOverlayPanel, portOverlayPanel, 
+            diskOverlayPanel, qtreeOverlayPanel, 
+            volumeOverlayPanel, poolOverlayPanel,
+            filesystemOverlayPanel, shareOverlayPanel;
         switch (node.type) {
             case "device":
                 this.storageOverview = node.details;
@@ -938,6 +1175,11 @@ export class StoragesComponent implements OnInit {
                     this.parentOverview = node;
                     poolParentOverlayPanel = overlaypanel;
                     poolParentOverlayPanel.toggle(event);
+                break;
+            case "filesystemParent":
+                    this.parentOverview = node;
+                    filesystemParentOverlayPanel = overlaypanel;
+                    filesystemParentOverlayPanel.toggle(event);
                 break;
             case "volNode":
                     this.volumeOverview = node;
@@ -963,6 +1205,21 @@ export class StoragesComponent implements OnInit {
                     this.diskOverview = node;
                     diskOverlayPanel = overlaypanel;
                     diskOverlayPanel.toggle(event);
+                break;
+            case "qtreeNode":
+                    this.qtreeOverview = node;
+                    qtreeOverlayPanel = overlaypanel;
+                    qtreeOverlayPanel.toggle(event);
+                break;
+            case "filesystemNode":
+                    this.filesystemOverview = node;
+                    filesystemOverlayPanel = overlaypanel;
+                    filesystemOverlayPanel.toggle(event);
+                break;
+            case "shareNode":
+                    this.shareOverview = node;
+                    shareOverlayPanel = overlaypanel;
+                    shareOverlayPanel.toggle(event);
                 break;
             default:
                 this.storageOverview = node;

--- a/src/app/shared/utils/consts.ts
+++ b/src/app/shared/utils/consts.ts
@@ -174,6 +174,16 @@ export const Consts = {
                 value: 'ibm'
             }
         ],
+        resources:{
+            volumes : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'fake_driver'],
+            pools : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'fake_driver'],
+            controllers : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'fake_driver'],
+            ports : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc'],
+            disks : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'fake_driver'],
+            qtrees : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'fake_driver'],
+            filesystems : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'fake_driver'],
+            shares: ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc']
+        },
         models: {
             'dellemc' : [
                 {

--- a/src/app/shared/utils/consts.ts
+++ b/src/app/shared/utils/consts.ts
@@ -175,14 +175,14 @@ export const Consts = {
             }
         ],
         resources:{
-            volumes : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'fake_driver'],
-            pools : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'fake_driver'],
-            controllers : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'fake_driver'],
-            ports : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc'],
-            disks : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'fake_driver'],
-            qtrees : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'fake_driver'],
-            filesystems : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'fake_driver'],
-            shares: ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc']
+            volumes : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc'],
+            pools : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc'],
+            controllers : ['oceanstor'],
+            ports : ['oceanstor'],
+            disks : ['oceanstor'],
+            qtrees : ['oceanstor'],
+            filesystems : ['oceanstor'],
+            shares: ['oceanstor']
         },
         models: {
             'dellemc' : [

--- a/src/app/shared/utils/consts.ts
+++ b/src/app/shared/utils/consts.ts
@@ -109,6 +109,9 @@ export const Consts = {
             'controllers' : 'resource-monitor/controllers',
             'ports' : 'resource-monitor/ports',
             'disks' : 'resource-monitor/disks',
+            'qtrees' : 'resource-monitor/qtrees',
+            'filesystems' : 'resource-monitor/filesystems',
+            'shares' : 'resource-monitor/shares',
             'alerts' : 'alertmanager/alerts'
         }
     },

--- a/src/assets/business/css/site.scss
+++ b/src/assets/business/css/site.scss
@@ -2222,7 +2222,10 @@ td.ui-datatable-emptymessage{
         padding-top: 1.5rem;
     }
 }
-.volume-parent-node ul.ui-treenode-children, .pool-parent-node ul.ui-treenode-children, .controller-parent-node ul.ui-treenode-children, .port-parent-node ul.ui-treenode-children, .disk-parent-node ul.ui-treenode-children{
+.volume-parent-node ul.ui-treenode-children, .pool-parent-node ul.ui-treenode-children, 
+.controller-parent-node ul.ui-treenode-children, .port-parent-node ul.ui-treenode-children, 
+.disk-parent-node ul.ui-treenode-children, .qtree-parent-node ul.ui-treenode-children, 
+.share-parent-node ul.ui-treenode-children, .filesystem-parent-node ul.ui-treenode-children {
     height: 100px;
     overflow-y: scroll;
     width: 50%;


### PR DESCRIPTION
**What type of PR is this?**
/kind new feature

**What this PR does / why we need it**:
This PR adds support for conditionally displaying the resources supported by a device. SODA Delfin supports SAN, NAS and  devices with Unified capabilities. Some devices may not have all the resources supported and the Dashboard should not display the resources for such devices.
Currently Delfin supports: Storage Pools, Volumes, Controllers, Ports and Disks display. These are displayed for all devices in the tree view in the storage dashboard and tab view in storage details page.
With this PR we display the resource type only if the device model supports the capability. This capability is maintained as a map at the dashboard in the following format:
```
 resources:{
            volumes : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'fake_driver'],
            pools : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'fake_driver'],
            controllers : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'fake_driver'],
            ports : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc'],
            disks : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'fake_driver'],
            qtrees : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'fake_driver'],
            filesystems : ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'fake_driver'],
            shares: ['vmax', 'unity', 'vnx', 'oceanstor', '3par', 'vsp', 'storwize_svc']
        },
```
In the above Ports and Shares resources are not supported in the fake_driver devices.

The map above has to be updated with the actual support matrix based on the device capability.

This PR also adds new resource types Qtree, Filesystem and Shares to devices that support NAS capabilities.

**Which issue(s) this PR fixes**:
Fixes #530 

**Test Report Added?**:
/kind TESTED

**Test Report**:
![nas-8](https://user-images.githubusercontent.com/19162717/110826511-25d2cf80-82bb-11eb-8a4c-c7f5450e0961.png)
![nas-9](https://user-images.githubusercontent.com/19162717/110826503-24a1a280-82bb-11eb-9900-c93222ba69b8.png)
![nas-10](https://user-images.githubusercontent.com/19162717/110826494-22d7df00-82bb-11eb-87b0-72dd2dc1206d.png)
![nas-1](https://user-images.githubusercontent.com/19162717/110287502-a4561580-800c-11eb-9303-98b71e80fc7a.png)
![nas-2](https://user-images.githubusercontent.com/19162717/110287501-a3bd7f00-800c-11eb-8e33-ea4fc3a1d922.png)
![nas-3](https://user-images.githubusercontent.com/19162717/110287497-a324e880-800c-11eb-95cc-652158f206c3.png)
![nas-4](https://user-images.githubusercontent.com/19162717/110287496-a324e880-800c-11eb-9c22-d7a14ea1ebab.png)
![nas-5](https://user-images.githubusercontent.com/19162717/110287494-a28c5200-800c-11eb-897e-57548ef83d4d.png)
![nas-6](https://user-images.githubusercontent.com/19162717/110287492-a1f3bb80-800c-11eb-9372-d1c68b1f6243.png)
![nas-7](https://user-images.githubusercontent.com/19162717/110287489-a029f800-800c-11eb-9666-5f7908d02075.png)




**Special notes for your reviewer**:
The device capability matrix pushed in this PR enables all resource types for all device models.
The actual support matrix must be updated before the PR is merged or in a subsequent PR.
 