### PR TITLE
Added Archive and retrieve support for Azure and GCP object storage

### DIFF
--- a/src/app/business/block/bucket-detail/bucket-detail.component.html
+++ b/src/app/business/block/bucket-detail/bucket-detail.component.html
@@ -82,11 +82,9 @@
                 </p-dialog>
                 <p-dialog styleClass="restore-dialog" header="Restore" [(visible)]="restoreDisplay" [width]="600" [height]="280" modal="modal">
                     <form [grid]="{label: 'ui-g-3', content:'ui-g-20'}" [formGroup]="restoreObjectForm" [errorMessage]="restoreObjectErrorMsg">
-                        <form-item *ngIf="bucketBackendType=='aws-s3'" label="{{restoreObjectFormLabel.days}}" [required]="true">
-                            <input id="restore-days" type="number" pInputText formControlName="days"/>
-                        </form-item>
-                        <form-item label="{{restoreObjectFormLabel.tier}}" [required]="true">
-                            <p-dropdown [style]="{'min-width':'150px','width':'220px'}" placeholder="Please select" [options]="restoreOptions" name='selectRestoreOptions' [(ngModel)]='selectRestoreOptions' formControlName="tier"></p-dropdown>
+                        <form-item *ngFor="let item of restoreFormItemsCopy" [label]="item.label" [required]="item.required">
+                            <input *ngIf="item.type=='number'" [id]="item.id" type="number" min="1" [(ngModel)]="item.value" [name]="item.name"  [formControlName]="item.formControlName"  pInputText />
+                            <p-dropdown *ngIf="item.type=='select'" [style]="{'min-width':'150px','width':'220px'}" placeholder="Please select" [options]="item.options" [name]="item.name" [(ngModel)]='selectRestoreOptions' [formControlName]="item.formControlName"></p-dropdown>
                         </form-item>
                     </form>
                     <p-footer>

--- a/src/app/business/block/bucket-detail/bucket-detail.component.html
+++ b/src/app/business/block/bucket-detail/bucket-detail.component.html
@@ -47,7 +47,7 @@
                     <p-column header="{{I18N.keyID['sds_block_volume_operation']}}" [style]="{'width': '200px'}">
                         <ng-template pTemplate="body" let-file="rowData" let-i="rowIndex">
                             <a (click)="downloadFile(file)" *ngIf="!file.newFolder">Download</a>
-                            <a (click)="showRestoreObject(file)" [ngClass]="{'a-rep-disabled':file.StorageClass!='GLACIER'}">Restore</a>
+                            <a (click)="showRestoreObject(file)" *ngIf="bucketBackendType!='gcp-s3'" [ngClass]="{'a-rep-disabled':file.StorageClass!='GLACIER'}">Restore</a>
                             <a [ngClass]="{'a-rep-disabled':file['disabled']}" (click)="deleteFile(file)">Delete</a>
                         </ng-template>
                     </p-column>
@@ -82,7 +82,7 @@
                 </p-dialog>
                 <p-dialog styleClass="restore-dialog" header="Restore" [(visible)]="restoreDisplay" [width]="600" [height]="280" modal="modal">
                     <form [grid]="{label: 'ui-g-3', content:'ui-g-20'}" [formGroup]="restoreObjectForm" [errorMessage]="restoreObjectErrorMsg">
-                        <form-item label="{{restoreObjectFormLabel.days}}" [required]="true">
+                        <form-item *ngIf="bucketBackendType=='aws-s3'" label="{{restoreObjectFormLabel.days}}" [required]="true">
                             <input id="restore-days" type="number" pInputText formControlName="days"/>
                         </form-item>
                         <form-item label="{{restoreObjectFormLabel.tier}}" [required]="true">
@@ -90,7 +90,7 @@
                         </form-item>
                     </form>
                     <p-footer>
-                        <button type="submit" class="ui-button-secondary" pButton (click)="restoreObject(restoreObjectForm.value)" label="{{I18N.keyID['ok']}}"></button>
+                        <button type="submit" [disabled]="restoreObjectForm.invalid" class="ui-button-secondary" pButton (click)="restoreObject(restoreObjectForm.value)" label="{{I18N.keyID['ok']}}"></button>
                         <button type="button" pButton (click)="cancelRestore()"  label="{{I18N.keyID['cancel']}}"></button>
                     </p-footer>
                 </p-dialog>

--- a/src/app/business/block/bucket-detail/bucket-detail.component.ts
+++ b/src/app/business/block/bucket-detail/bucket-detail.component.ts
@@ -113,6 +113,7 @@ export class BucketDetailComponent implements OnInit {
       required: 'true',
       id: 'days',
       type: 'number',
+      options: [],
       name: 'days',
       formControlName: 'days',
       value: 1,

--- a/src/app/business/block/bucket-detail/bucket-detail.component.ts
+++ b/src/app/business/block/bucket-detail/bucket-detail.component.ts
@@ -123,7 +123,7 @@ export class BucketDetailComponent implements OnInit {
       required: 'true',
       id: 'tier',
       type: 'select',
-      options: this.restoreOptions,
+      options: [],
       name: 'tier',
       formControlName: 'tier',
       arr:['aws-s3']
@@ -133,7 +133,7 @@ export class BucketDetailComponent implements OnInit {
       required: 'true',
       id: 'storage-class',
       type: 'select',
-      options: this.restoreOptions,
+      options: [],
       name: 'storage-class',
       formControlName: 'storageClass',
       arr:['azure-blob']
@@ -502,7 +502,7 @@ export class BucketDetailComponent implements OnInit {
               this.restoreFormItemsCopy.push(item)
               this.restoreObjectForm.controls[`${item.formControlName}`].setValidators(Validators.required);
           }else{
-              this.restoreObjectForm.controls[`${item.formControlName}`].setValidators('');
+              this.restoreObjectForm.controls[`${item.formControlName}`].setValidators([]);
           }
       })
     })

--- a/src/app/business/block/bucket-detail/bucket-detail.module.ts
+++ b/src/app/business/block/bucket-detail/bucket-detail.module.ts
@@ -37,7 +37,7 @@ let routers = [{
     HttpClientModule,
     SplitButtonModule,
     GrowlModule,
-    AclModule,
+    AclModule
   ],
   declarations: [
     BucketDetailComponent

--- a/src/app/business/block/bucket-detail/bucket-detail.module.ts
+++ b/src/app/business/block/bucket-detail/bucket-detail.module.ts
@@ -7,6 +7,7 @@ import { LifeCycleModule } from './lifeCycle/lifeCycle.module';
 import { AclModule } from './acl/acl.module';
 import { TabViewModule,ButtonModule, DataTableModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputSwitchModule, InputTextareaModule, 
   ConfirmDialogModule ,ConfirmationService,CheckboxModule,DropdownModule, SplitButtonModule, GrowlModule} from './../../../components/common/api';
+
 import { HttpService } from './../../../shared/service/Http.service';
 import { BucketService } from '../buckets.service';
 import { HttpClientModule } from '@angular/common/http';

--- a/src/app/shared/utils/consts.ts
+++ b/src/app/shared/utils/consts.ts
@@ -117,6 +117,10 @@ export const Consts = {
             {
                 label: "Hot",
                 value: "Hot"
+            },
+            {
+                label: "Cold",
+                value: "Cold"
             }
         ]
     },

--- a/src/app/shared/utils/consts.ts
+++ b/src/app/shared/utils/consts.ts
@@ -84,22 +84,42 @@ export const Consts = {
                 label: 'S3 GLACIER',
                 value: 'GLACIER'
             }
+        ],
+        'azure-blob' : [
+            {
+                label: 'Archive',
+                value: 'Archive'
+            }
+        ],
+        'gcp-s3' : [
+            {
+                label: 'Archive',
+                value: 'Archive'
+            }
         ]
     },
-    RETRIEVAL_OPTIONS: [
-        {
-            label: "Expedited",
-            value: "Expedited"
-        },
-        {
-            label: "Standard",
-            value: "Standard"
-        },
-        {
-            label: "Bulk",
-            value: "Bulk"
-        }
-    ],
+    RETRIEVAL_OPTIONS: {
+        'aws-s3' : [
+            {
+                label: "Expedited",
+                value: "Expedited"
+            },
+            {
+                label: "Standard",
+                value: "Standard"
+            },
+            {
+                label: "Bulk",
+                value: "Bulk"
+            }
+        ],
+        'azure-blob' : [
+            {
+                label: "Hot",
+                value: "Hot"
+            }
+        ]
+    },
     API: {
 
         DELFIN : {


### PR DESCRIPTION

**What type of PR is this?**
 /kind enhancement

**What this PR does / why we need it**:
This PR adds archive and retrieve(rehydrate) support for Azure and GCP cloud backend object storage.
Previously SODA multicloud supported only AWS and now it is enhanced to support Azure and GCP.
This PR allows the user to use the Dashboard and archive an object to Azure and GCP clouds and retrieve from the same.

**Which issue(s) this PR fixes**:
Fixes #532

**Test Report Added?**:
/kind TESTED


**Test Report**:
![archive-azure-1](https://user-images.githubusercontent.com/19162717/110745534-6aca1800-8261-11eb-8d5e-02f0fc9e6b91.png)
![archive-azure-2](https://user-images.githubusercontent.com/19162717/110745537-6c93db80-8261-11eb-9171-8f2dfb8df0a7.png)
![archive-azure-3](https://user-images.githubusercontent.com/19162717/110745544-6dc50880-8261-11eb-8999-60e2fbd4612f.png)
![image](https://user-images.githubusercontent.com/19162717/110925297-05e9ed00-8349-11eb-96d2-38cfdeb1a62c.png)
![image](https://user-images.githubusercontent.com/19162717/110925309-097d7400-8349-11eb-98c2-df71b1d63f9e.png)

![archive-gcp-6](https://user-images.githubusercontent.com/19162717/110745549-6ef63580-8261-11eb-9153-03e471121e0a.png)
![restore-azure-4](https://user-images.githubusercontent.com/19162717/110745553-70276280-8261-11eb-9f08-c0211337a3df.png)
![restore-azure-5](https://user-images.githubusercontent.com/19162717/110745558-71588f80-8261-11eb-8bda-95df1d29400f.png)


**Special notes for your reviewer**:
