### PR TITLE
Removed bucket param from backend registration for AWS, GCP and Azure

### DIFF
--- a/src/app/business/home/home.component.ts
+++ b/src/app/business/home/home.component.ts
@@ -84,7 +84,7 @@ export class HomeComponent implements OnInit {
             type: 'text',
             name: 'bucket',
             formControlName: 'bucket',
-            arr:['aws-s3','azure-blob','hw-obs','fusionstorage-object','ceph-s3','gcp-s3','ibm-cos', 'alibaba-oss']
+            arr:['hw-obs','fusionstorage-object','ceph-s3','ibm-cos', 'alibaba-oss']
         },
         {
             label: 'Access Key',


### PR DESCRIPTION

**What type of PR is this?**
 /kind enhancement

**What this PR does / why we need it**:
This PR removes the mandatory bucket name parameter from the backend registration form for AWS, Azure and GCP cloud providers. This is as per the latest changes made to the SODA Multicloud registration process.

**Which issue(s) this PR fixes**:
Fixes #535 

**Test Report Added?**:
/kind TESTED

**Test Report**:
**Registration for AWS - Bucket name removed**
![image](https://user-images.githubusercontent.com/19162717/110909101-b221d880-8335-11eb-8f42-0c814841c8ba.png)

**Registration for Azure - Bucket name removed**
![image](https://user-images.githubusercontent.com/19162717/110909116-b5b55f80-8335-11eb-99f6-0c57b0180785.png)

**Registration for GCP - Bucket name removed**
![image](https://user-images.githubusercontent.com/19162717/110909124-b9e17d00-8335-11eb-9a59-63287c694001.png)

**Special notes for your reviewer**:
