### PR TITLE
Removed the link to performance monitoring configuration from dashboard

### DIFF
--- a/src/app/business/delfin/storage-details/storage-details.component.html
+++ b/src/app/business/delfin/storage-details/storage-details.component.html
@@ -12,7 +12,6 @@
             
         </div>
         <div class="right">
-            <button pButton type="button" (click)="showPerfConfigDialog()" icon="fa-cog" label="Configure Metric Collection"></button>
             <button pButton type="button" (click)="syncStorage(selectedStorageId)" icon="fa-exchange" label="Sync Storage"></button>
             <button class="" title="Refresh" label="Refresh" pButton type="button" (click)="getStorageById(selectedStorageId)" icon="fa-refresh"></button>
         </div>

--- a/src/app/business/delfin/storages/storages.component.ts
+++ b/src/app/business/delfin/storages/storages.component.ts
@@ -233,14 +233,6 @@ export class StoragesComponent implements OnInit {
                 },
                 disabled:false
             },
-	    {
-                "label": "Configure Metric Collection",
-
-                command: () => {
-                    this.showPerfConfigDialog(this.selectStorage);
-                },
-                disabled:false
-            },
             {
                 "label": this.i18n.keyID['sds_block_volume_delete'],
                 command: () => {
@@ -1138,14 +1130,6 @@ export class StoragesComponent implements OnInit {
                     "label": "Sync Storage Device",
                     command: () => {
                         this.syncStorage(node['details'].id);
-                    },
-                    disabled:false
-                },
-                {
-                    "label": "Configure Metric Collection",
-    
-                    command: () => {
-                        this.showPerfConfigDialog(node['details']);
                     },
                     disabled:false
                 },


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What this PR does / why we need it**:
This PR removes the links to the performance metric collection configuration screens. 
The performance metrics collection configuration is now implicitly done at the time of device registration in Delfin.
The user does not have to manually configure a device to collect performance metrics.

**Which issue(s) this PR fixes**:
Fixes #529 

**Test Report Added?**:
/kind TESTED

**Test Report**:
![remove-perf-config-1](https://user-images.githubusercontent.com/19162717/111793767-96956f80-88eb-11eb-97ae-c47b58cdaab1.png)

![remove-perf-config-2](https://user-images.githubusercontent.com/19162717/111793762-94cbac00-88eb-11eb-90e5-abe61b2b19c6.png)

![remove-perf-config-3](https://user-images.githubusercontent.com/19162717/111793753-92695200-88eb-11eb-9d3a-421a54551c85.png)

**Special notes for your reviewer**:
