### PR TITLE
Fixed incorrect share and qtree status display. Added share overview to storage summary tree view widget

### DIFF
--- a/src/app/business/delfin/qtrees/qtrees.component.html
+++ b/src/app/business/delfin/qtrees/qtrees.component.html
@@ -16,12 +16,14 @@
             <a (mouseenter)="showQtreeOverview($event, qtree, qtreeOverviewPanel)" (mouseleave)="showQtreeOverview($event, qtree, qtreeOverviewPanel)">{{qtree.name}}</a>
         </ng-template>
     </p-column>    
-    <p-column field="status" header="Status">
+    <p-column field="security_mode" header="Security Mode">
         <ng-template pTemplate="body" let-qtree="rowData">
-            <span class="storage-status-icon" [ngClass]="{normal: qtree.status=='normal', abnormal: qtree.status=='abnormal' || qtree.status=='unknown' || qtree.status=='offline'}"><i class="fa fa-circle"></i></span>
-            <span *ngIf="qtree.status=='normal'">Normal</span>
-            <span *ngIf="qtree.status=='abnormal' || qtree.status=='unknown'">Unknown</span>
-            <span *ngIf="qtree.status=='offline'">Offline</span>
+            <span>{{qtree.security_mode ? qtree.security_mode : '--'}}</span>
+        </ng-template>
+    </p-column>
+    <p-column field="native_filesystem_id" header="Native Filesystem ID">
+        <ng-template pTemplate="body" let-qtree="rowData">
+            <span>{{qtree.native_filesystem_id ? qtree.native_filesystem_id : '--'}}           </span>
         </ng-template>
     </p-column>
     <p-column field="created_at" header="Created At">
@@ -46,13 +48,10 @@
                             {{qtree.name}}
                         </div>
                         <div class="ui-grid-col-2">
-                            {{label.status}}:
+                            {{label.security_mode}}:
                         </div>
                         <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="qtree">
-                            <span class="storage-status-icon" [ngClass]="{normal: qtree.status=='normal', abnormal: qtree.status=='abnormal' || qtree.status=='unknown' || qtree.status=='offline'}"><i class="fa fa-circle"></i></span>
-                            <span *ngIf="qtree.status=='normal'">Normal</span>
-                            <span *ngIf="qtree.status=='abnormal' || qtree.status=='unknown'">Unknown</span>
-                            <span *ngIf="qtree.status=='offline'">Offline</span>
+                            {{qtree.security_mode ? qtree.security_mode : '--'}}  
                         </div>
                         <div class="ui-grid-col-2">
                             {{label.created_at}}:
@@ -101,24 +100,22 @@
                             </a>
                         </div>
                         <div class="ui-grid-col-2">
-                            {{label.native_filesystem_id}}:  
+                            {{label.native_filesystem_id}}:
                         </div>
                         <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="qtree">
-                            {{qtree.native_filesystem_id ? qtree.native_filesystem_id : '--'}}           
+                            {{qtree.native_filesystem_id ? qtree.native_filesystem_id : '--'}}
                         </div>
                         <div class="ui-grid-col-2">
-                            {{label.security_mode}}:
+                            {{label.path}}:
                         </div>
                         <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="qtree">
-                            {{qtree.security_mode ? qtree.security_mode : '--'}}           
+                            {{qtree.path ? qtree.path : '--'}}
                         </div>
                     </div>
                     <div class="ui-grid-row details-basic-item-class">
                         <div class="ui-grid-col-2">
-                            {{label.path}}:
                         </div>
                         <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="qtree">
-                            {{qtree.path ? qtree.path : '--'}}   
                         </div>
                         <div class="ui-grid-col-2">
 

--- a/src/app/business/delfin/qtrees/qtrees.component.html
+++ b/src/app/business/delfin/qtrees/qtrees.component.html
@@ -12,7 +12,6 @@
     <p-column expander="true" styleClass="col-icon" [style]="{'width': '3%'}"></p-column>
     <p-column field="name" header="Name">
         <ng-template pTemplate="body" let-qtree="rowData">
-            <!-- {{qtree.name}} -->
             <a (mouseenter)="showQtreeOverview($event, qtree, qtreeOverviewPanel)" (mouseleave)="showQtreeOverview($event, qtree, qtreeOverviewPanel)">{{qtree.name}}</a>
         </ng-template>
     </p-column>    
@@ -139,17 +138,6 @@
 <p-overlayPanel styleClass="overview-panel" #qtreeOverviewPanel>
     <div class="ui-g overview-title">
         <h4>{{qtreeOverview && qtreeOverview.name}}</h4>
-    </div>
-    <div class="ui-g ui-g-nopad overview-item" >
-        <div class="ui-g-6">
-            <span class="overview-item-label">Status: </span>
-        </div>
-        <div *ngIf="qtreeOverview" class="ui-g-6">
-            <span class="storage-status-icon" [ngClass]="{normal:  qtreeOverview && qtreeOverview.status =='normal', abnormal: qtreeOverview && qtreeOverview.status =='abnormal' || qtreeOverview.status =='unknown'}"><i class="fa fa-circle"></i></span>
-            <span *ngIf="qtreeOverview && qtreeOverview.status=='normal'">Normal</span>
-            <span *ngIf=" qtreeOverview && qtreeOverview.status=='abnormal' || qtreeOverview.status=='unknown'">Unknown</span>
-            <span *ngIf=" qtreeOverview && qtreeOverview.status=='offline'">Offline</span>
-        </div>
     </div>
     <div class="ui-g overview-item">
         <div class="ui-g-6">

--- a/src/app/business/delfin/shares/shares.component.html
+++ b/src/app/business/delfin/shares/shares.component.html
@@ -12,16 +12,12 @@
     <p-column expander="true" styleClass="col-icon" [style]="{'width': '3%'}"></p-column>
     <p-column field="name" header="Name">
         <ng-template pTemplate="body" let-share="rowData">
-            <!-- {{share.name}} -->
             <a (mouseenter)="showShareOverview($event, share, shareOverviewPanel)" (mouseleave)="showShareOverview($event, share, shareOverviewPanel)">{{share.name}}</a>
         </ng-template>
     </p-column>    
-    <p-column field="status" header="Status">
+    <p-column field="protocol" header="Protocol">
         <ng-template pTemplate="body" let-share="rowData">
-            <span class="storage-status-icon" [ngClass]="{normal: share.status=='normal', abnormal: share.status=='abnormal' || share.status=='unknown' || share.status=='offline'}"><i class="fa fa-circle"></i></span>
-            <span *ngIf="share.status=='normal'">Normal</span>
-            <span *ngIf="share.status=='abnormal' || share.status=='unknown'">Unknown</span>
-            <span *ngIf="share.status=='offline'">Offline</span>
+            {{share.protocol ? share.protocol : '--'}}
         </ng-template>
     </p-column>
     <p-column field="created_at" header="Created At">
@@ -46,13 +42,10 @@
                             {{share.name}}
                         </div>
                         <div class="ui-grid-col-2">
-                            {{label.status}}:
+                            {{label.protocol}}:
                         </div>
                         <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="share">
-                            <span class="storage-status-icon" [ngClass]="{normal: share.status=='normal', abnormal: share.status=='abnormal' || share.status=='unknown' || share.status=='offline'}"><i class="fa fa-circle"></i></span>
-                            <span *ngIf="share.status=='normal'">Normal</span>
-                            <span *ngIf="share.status=='abnormal' || share.status=='unknown'">Unknown</span>
-                            <span *ngIf="share.status=='offline'">Offline</span>
+                            {{share.protocol ? share.protocol : '--'}}
                         </div>
                         <div class="ui-grid-col-2">
                             {{label.created_at}}:
@@ -107,24 +100,24 @@
                             {{share.native_filesystem_id ? share.native_filesystem_id : '--'}}           
                         </div>
                         <div class="ui-grid-col-2">
-                            {{label.protocol}}:
+                            {{label.path}}:
                         </div>
                         <div class="ui-grid-col-3 details-basic-item-value-color" *ngIf="share">
-                            {{share.protocol ? share.protocol : '--'}}           
+                            {{share.path ? share.path : '--'}}
                         </div>
                     </div>
                     <div class="ui-grid-row details-basic-item-class">
                         <div class="ui-grid-col-2">
-                            {{label.path}}:
+                            {{label.native_qtree_id}}:
                         </div>
                         <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="share">
-                            {{share.path ? share.path : '--'}}   
+                            {{share.native_qtree_id ? share.native_qtree_id : '--'}}
                         </div>
                         <div class="ui-grid-col-2">
-                            {{label.native_qtree_id}}:  
+                              
                         </div>
                         <div class="ui-grid-col-2 details-basic-item-value-color" *ngIf="share">
-                            {{share.native_qtree_id ? share.native_qtree_id : '--'}}           
+                            
                         </div>
                         <div class="ui-grid-col-2">
                             
@@ -142,17 +135,6 @@
 <p-overlayPanel styleClass="overview-panel" #shareOverviewPanel>
     <div class="ui-g overview-title">
         <h4>{{shareOverview && shareOverview.name}}</h4>
-    </div>
-    <div class="ui-g ui-g-nopad overview-item" >
-        <div class="ui-g-6">
-            <span class="overview-item-label">Status: </span>
-        </div>
-        <div *ngIf="shareOverview" class="ui-g-6">
-            <span class="storage-status-icon" [ngClass]="{normal:  shareOverview && shareOverview.status =='normal', abnormal: shareOverview && shareOverview.status =='abnormal' || shareOverview.status =='unknown'}"><i class="fa fa-circle"></i></span>
-            <span *ngIf="shareOverview && shareOverview.status=='normal'">Normal</span>
-            <span *ngIf=" shareOverview && shareOverview.status=='abnormal' || shareOverview.status=='unknown'">Unknown</span>
-            <span *ngIf=" shareOverview && shareOverview.status=='offline'">Offline</span>
-        </div>
     </div>
     <div class="ui-g overview-item">
         <div class="ui-g-6">

--- a/src/app/business/delfin/storages/storages.component.html
+++ b/src/app/business/delfin/storages/storages.component.html
@@ -1370,14 +1370,6 @@
     </div>
     <div class="ui-g overview-item">
         <div class="ui-g-6">
-            Vendor / Model
-        </div>
-        <div class="ui-g-6">
-            {{ selectedStorageDetails && selectedStorageDetails.vendor}} {{selectedStorageDetails && selectedStorageDetails.model}}
-        </div>
-    </div>
-    <div class="ui-g overview-item">
-        <div class="ui-g-6">
             <span class="overview-item-label">
               Storage ID  
             </span>

--- a/src/app/business/delfin/storages/storages.component.html
+++ b/src/app/business/delfin/storages/storages.component.html
@@ -1363,6 +1363,55 @@
         </div>
     </div>
 </p-overlayPanel>
+<p-overlayPanel styleClass="overview-panel" #shareOverviewPanel>
+    <div class="ui-g overview-title">
+        <h4>{{shareOverview && shareOverview.details.name}}</h4>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            Vendor / Model
+        </div>
+        <div class="ui-g-6">
+            {{ selectedStorageDetails && selectedStorageDetails.vendor}} {{selectedStorageDetails && selectedStorageDetails.model}}
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            <span class="overview-item-label">
+              Storage ID  
+            </span>
+        </div>
+        <div class="ui-g-6">
+            <span>
+                {{ shareOverview && shareOverview.details.storage_id}}
+            </span>
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            Protocol
+        </div>
+        <div class="ui-g-6">
+            {{ shareOverview && shareOverview.details.protocol}}
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            Path
+        </div>
+        <div class="ui-g-6">
+            {{shareOverview && shareOverview.details.path}}
+        </div>
+    </div>
+    <div class="ui-g overview-item">
+        <div class="ui-g-6">
+            
+        </div>
+        <div class="ui-g-6">
+            
+        </div>
+    </div>
+</p-overlayPanel>
 <p-overlayPanel styleClass="overview-panel" #quotaOverviewPanel>
     <div class="ui-g overview-title">
         <h4>{{quotaOverview && quotaOverview.details.native_quota_id}}</h4>

--- a/src/app/business/delfin/storages/storages.component.html
+++ b/src/app/business/delfin/storages/storages.component.html
@@ -1244,15 +1244,16 @@
     <div class="ui-g overview-title">
         <h4>{{qtreeOverview && qtreeOverview.details.name}}</h4>
     </div>
-    <div class="ui-g ui-g-nopad overview-item" >
+    <div class="ui-g overview-item">
         <div class="ui-g-6">
-            <span class="overview-item-label">Status: </span>
+            <span class="overview-item-label">
+              Storage ID  
+            </span>
         </div>
-        <div *ngIf="qtreeOverview" class="ui-g-6">
-            <span class="storage-status-icon" [ngClass]="{normal:  qtreeOverview && qtreeOverview.details.status =='normal', abnormal: qtreeOverview && qtreeOverview.details.status =='abnormal' || qtreeOverview.details.status =='unknown'}"><i class="fa fa-circle"></i></span>
-            <span *ngIf="qtreeOverview && qtreeOverview.details.status=='normal'">Normal</span>
-            <span *ngIf=" qtreeOverview && qtreeOverview.details.status=='abnormal' || qtreeOverview.details.status=='unknown'">Unknown</span>
-            <span *ngIf=" qtreeOverview && qtreeOverview.details.status=='offline'">Offline</span>
+        <div class="ui-g-6">
+            <span>
+                {{ qtreeOverview && qtreeOverview.details.storage_id}}
+            </span>
         </div>
     </div>
     <div class="ui-g overview-item">


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug fix

**What this PR does / why we need it**:
This PR fixes the issue of status shown for Qtree and Share resources.
This PR also fixes the issue of share overview not shown on hovering on share name in the tree view in storage summary page.

**Which issue(s) this PR fixes**:
Fixes #551 #552 

**Test Report Added?**:
 /kind TESTED


**Test Report**:

**Qtree no status field**
![image](https://user-images.githubusercontent.com/19162717/112005641-f76db380-8b48-11eb-856e-69eeca69e4bd.png)

**Shares no status field**
![image](https://user-images.githubusercontent.com/19162717/112005705-048aa280-8b49-11eb-8272-b6d43df4c031.png)

**Shares overview on hover**
![image](https://user-images.githubusercontent.com/19162717/112005558-e329b680-8b48-11eb-8135-af260afb5733.png)

**Special notes for your reviewer**:
