### PR TITLE
Fixed the restore tier for Azure from Cold to Cool.

### DIFF
--- a/src/app/shared/utils/consts.ts
+++ b/src/app/shared/utils/consts.ts
@@ -119,8 +119,8 @@ export const Consts = {
                 value: "Hot"
             },
             {
-                label: "Cold",
-                value: "Cold"
+                label: "Cool",
+                value: "Cool"
             }
         ]
     },


### PR DESCRIPTION
**What type of PR is this?**
/kind bug fix

**What this PR does / why we need it**:
This PR fixes the incorrect restore storage class from `Cold` to `Cool` for Azure backends.

**Which issue(s) this PR fixes**:
Fixes #

**Test Report Added?**:
/kind TESTED


**Test Report**:
![azure-restore-classs](https://user-images.githubusercontent.com/19162717/112158030-c905dc00-8c0d-11eb-93f2-05ae8530cf75.png)


**Special notes for your reviewer**:
Tested with latest master
![azure-restore-class-2](https://user-images.githubusercontent.com/19162717/112253552-f17ced00-8c84-11eb-8c3e-dbbf968a9359.png)
![azure-restore-class-1](https://user-images.githubusercontent.com/19162717/112253333-89c6a200-8c84-11eb-9b5b-d8751c5062e1.png)
![azure-restore-class-4](https://user-images.githubusercontent.com/19162717/112253551-f0e45680-8c84-11eb-88fb-7ee8ef79c17e.png)
![azure-restore-class-5](https://user-images.githubusercontent.com/19162717/112253550-ef1a9300-8c84-11eb-95d0-1bc17447a8ff.png)
![azure-restore-class-3](https://user-images.githubusercontent.com/19162717/112253328-87fcde80-8c84-11eb-85d3-cb121e651c12.png)