### PR TITLE
Added success and error notification for delete object API

### DIFF
--- a/src/app/business/block/bucket-detail/bucket-detail.component.ts
+++ b/src/app/business/block/bucket-detail/bucket-detail.component.ts
@@ -823,11 +823,17 @@ export class BucketDetailComponent implements OnInit {
                         options = this.BucketService.getSignatureOptions(requestOptions, options);
                         this.BucketService.deleteFile(`${this.bucketId}/${objectKey}`,options).subscribe((res) => {
                           this.getAlldir();
+                          this.msgs = [];
+                          this.msgs.push({severity: 'success', summary: 'Success', detail: file.Key + ' has been deleted successfully.'});
+                        }, (error)=>{
+                          this.msgs = [];
+                          this.msgs.push({severity: 'error', summary: "Error deleting " + file.Key, detail: error._body});
                         });
                     })
                     
                     break;
                   case "deleteMilti":
+                    this.msgs = [];
                    file.forEach(element => {
                       let objectKey = element.Key;
                       //If you want to delete files from a folder, you must include the name of the folder
@@ -844,8 +850,11 @@ export class BucketDetailComponent implements OnInit {
                         options['headers'] = new Headers();
                         options = this.BucketService.getSignatureOptions(requestOptions, options);
                           this.BucketService.deleteFile(`${this.bucketId}/${objectKey}`,options).subscribe((res) => {
-                            this.getAlldir();
-                          });
+                          this.getAlldir();
+                          this.msgs.push({severity: 'success', summary: 'Success', detail: element.Key + ' has been deleted successfully.'});
+                        }, (error)=>{
+                          this.msgs.push({severity: 'error', summary: "Error deleting " + element.Key, detail: error._body});
+                        });
                       })
                    });
                     break;


### PR DESCRIPTION
**What type of PR is this?**
/kind bug fix

**What this PR does / why we need it**:
This PR fixes the issue of notification not shown for success or error of delete object.

**Which issue(s) this PR fixes**:
Fixes #556 

**Test Report Added?**:
/kind TESTED

**Test Report**:
![delete-object-1](https://user-images.githubusercontent.com/19162717/112159490-3bc38700-8c0f-11eb-80b3-7d1847bac5ac.png)
![delete-object-2](https://user-images.githubusercontent.com/19162717/112159498-3ebe7780-8c0f-11eb-81c3-5c3b6170d6a4.png)
![delete-object-3](https://user-images.githubusercontent.com/19162717/112159505-3fefa480-8c0f-11eb-91c8-08cc60ed7e28.png)
![delete-object-4](https://user-images.githubusercontent.com/19162717/112159509-4120d180-8c0f-11eb-8ace-4e1417a25e6f.png)
naj
![delete-object-5](https://user-images.githubusercontent.com/19162717/112159512-41b96800-8c0f-11eb-9c1d-21b1d45114ff.png)

**Special notes for your reviewer**:
