### PR TITLE
Fixed the issue of volume source line displayed incorrectly in volume details page

### DIFF
--- a/src/app/business/block/volume-detail/volume-detail.component.ts
+++ b/src/app/business/block/volume-detail/volume-detail.component.ts
@@ -54,8 +54,8 @@ export class VolumeDetailComponent implements OnInit {
       this.ProfileService.getProfileById(this.volume.profileId).subscribe((res)=>{
           this.volume.profileName = res.json().name;
       })
-
-      if(this.volume.snapshotId != ""){
+      
+      if(this.volume.snapshotId && this.volume.snapshotId != ""){
         this.showVolumeSource = true;
         this.volumeSource = this.i18n.keyID['sds_block_volume_source'].replace("{{}}", this.volume.snapshotId);
       }


### PR DESCRIPTION

**What type of PR is this?**
 /kind bug fix

**What this PR does / why we need it**:
This PR fixes the issue of volume source line " This volume is generated from snapshot..." displayed in the volume details Basic information section when the volume is not generated from a snapshot.
This issue occured due to the snapshot ID key being removed from the API response as per the API spec update. The check on the snapshot Id being not empty was there but there was no check on whether the field does not exist.

**Which issue(s) this PR fixes**:
Fixes #558 

**Test Report Added?**:
 /kind TESTED

**Test Report**:
![vol-details-snap-002](https://user-images.githubusercontent.com/19162717/112824747-89753f00-90a8-11eb-8ac8-af63c2d99588.png)
![vol-details-snap-001](https://user-images.githubusercontent.com/19162717/112824759-8b3f0280-90a8-11eb-98d6-23bfe0c3b7cb.png)
sanil
**Special notes for your reviewer**:
