### PR TITLE
Fixed error and success notifications not shown to user on deleting volume group.

### DIFF
--- a/src/app/business/block/volumeGroup.component.ts
+++ b/src/app/business/block/volumeGroup.component.ts
@@ -8,7 +8,7 @@ import { FormControl, FormGroup, FormBuilder, Validators, ValidatorFn, AbstractC
 import { VolumeService ,VolumeGroupService} from './volume.service';
 import { ProfileService } from './../profile/profile.service';
 import { AvailabilityZonesService } from './../resource/resource.service';
-import { ConfirmationService,ConfirmDialogModule} from '../../components/common/api';
+import { ConfirmationService,ConfirmDialogModule, Message} from '../../components/common/api';
 import { Router } from '@angular/router';
 
 @Component({
@@ -31,6 +31,7 @@ export class VolumeGroupComponent implements OnInit{
     showModifyGroup :boolean = false;
     volumeGroupForm:any;
     modifyGroupForm:any;
+    msgs: Message[];
     validRule= {
         'name':'^[a-zA-Z]{1}([a-zA-Z0-9]|[_]){0,127}$'
     };
@@ -194,15 +195,26 @@ export class VolumeGroupComponent implements OnInit{
             isWarning: warming,
             accept: ()=>{
                 try {
+                    this.msgs = [];
                     if(func === "delete"){
                         this.volumeGroupService.deleteVolumeGroup(this.currentGroup.id).subscribe((res) => {
                             this.getVolumeGroups();
-                        })
+                            let successMesg = "Volume group " + this.currentGroup.name  +" has been deleted successfully.";
+                            this.msgs.push({severity: 'success', summary: 'Success', detail: successMesg});
+                        }, (error) =>{
+                            let errorMesgTitle = "Error Deleting " + this.currentGroup.name;
+                            this.msgs.push({severity: 'error', summary: errorMesgTitle, detail: error.json().message});
+                        });
                     }else if(func === "multiDelete"){
                         this.selectedVolumeGroups.forEach(item=>{
                             this.volumeGroupService.deleteVolumeGroup(item.id).subscribe((res) => {
                                 this.getVolumeGroups();
-                            })
+                                let successMesg = "Volume group " + item.name  +" has been deleted successfully.";
+                                this.msgs.push({severity: 'success', summary: 'Success', detail: successMesg});
+                            }, (error) =>{
+                                let errorMesgTitle = "Error Deleting " + item.name;
+                                this.msgs.push({severity: 'error', summary: errorMesgTitle, detail: error.json().message});
+                            });
                         });
                         this.selectedVolumeGroups = [];
                     }

--- a/src/app/business/block/volumeGroup.html
+++ b/src/app/business/block/volumeGroup.html
@@ -1,3 +1,4 @@
+<p-growl [value]="msgs" [sticky]="false" [life]="6000"></p-growl>
 <div class="table-toolbar">
     <div class="left">
         <button class="ui-button-secondary" pButton type="button" label="{{I18N.keyID['sds_block_volume_create']}}" (click)="createVolumeGroup()"></button>

--- a/src/app/business/block/volumeGroup.module.ts
+++ b/src/app/business/block/volumeGroup.module.ts
@@ -1,6 +1,6 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { VolumeGroupComponent } from './volumeGroup.component';
-import { ButtonModule, DataTableModule, InputTextModule, DialogModule,FormModule,MultiSelectModule ,DropdownModule,InputTextareaModule} from '../../components/common/api';
+import { ButtonModule, DataTableModule, InputTextModule, DialogModule,FormModule,MultiSelectModule ,DropdownModule,InputTextareaModule, GrowlModule} from '../../components/common/api';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { HttpService } from './../../shared/service/Http.service';
 import { VolumeService ,VolumeGroupService} from './volume.service';
@@ -10,7 +10,21 @@ import { RouterModule } from '@angular/router';
 
 @NgModule({
   declarations: [ VolumeGroupComponent ],
-  imports: [ ButtonModule, DataTableModule, InputTextModule, DialogModule,FormModule,MultiSelectModule,DropdownModule,ReactiveFormsModule,FormsModule,ConfirmDialogModule,InputTextareaModule,RouterModule],
+  imports: [ 
+    ButtonModule, 
+    DataTableModule, 
+    InputTextModule, 
+    DialogModule,
+    FormModule,
+    MultiSelectModule,
+    DropdownModule,
+    ReactiveFormsModule,
+    FormsModule,
+    ConfirmDialogModule,
+    InputTextareaModule,
+    GrowlModule,
+    RouterModule
+  ],
   exports: [ VolumeGroupComponent ],
   providers: [
     HttpService,


### PR DESCRIPTION

**What type of PR is this?**
/kind bug fix

**What this PR does / why we need it**:
This PR fixes the issue of notification not shown to user when deleting the volume group and there is an error from the API.
This PR also adds notifications for successful deleting a volume group.

**Which issue(s) this PR fixes**:
Fixes #559 

**Test Report Added?**:
/kind TESTED


**Test Report**:
![del-vol-group-003](https://user-images.githubusercontent.com/19162717/112828508-69944a00-90ad-11eb-9add-868a154e6018.png)
![del-vol-group-002](https://user-images.githubusercontent.com/19162717/112828512-6ac57700-90ad-11eb-9097-95a4b5c72ebe.png)

![del-vol-group-004](https://user-images.githubusercontent.com/19162717/112828502-68631d00-90ad-11eb-9304-d25ae65f5477.png)
![del-vol-group-001](https://user-images.githubusercontent.com/19162717/112828516-6b5e0d80-90ad-11eb-8910-1c4aac54ffac.png)


**Special notes for your reviewer**:
