### PR TITLE
Use shared modules to inject dependencies. Remove duplication of framework component and common modules in all modules.

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,14 +1,10 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { CommonModule } from '@angular/common';
 import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { HttpModule } from "@angular/http";
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { SharedModule } from './shared/shared.module';
-import { DropMenuModule, PanelModule, SelectButtonModule, ButtonModule, InputTextModule, ConfirmationService,ConfirmDialogModule } from './components/common/api';
-import { ProgressBarModule } from './components/progressbar/progressbar';
-import { ScrollPanelModule } from './components/scrollpanel/scrollpanel';
 import { LocationStrategy, HashLocationStrategy } from '@angular/common';
 import { BucketService } from './business/block/buckets.service';
 import { HttpService } from './shared/service/Http.service';
@@ -22,24 +18,15 @@ import { MessagesModule } from './components/messages/messages';
   ],
   imports: [
     BrowserModule,
-    CommonModule,
     AppRoutingModule,
     MessagesModule,
     HttpModule,
     BrowserAnimationsModule,
     SharedModule.forRoot(),
-    JoyrideModule.forRoot(),
-    DropMenuModule,
-    PanelModule,
-    ScrollPanelModule,
-    SelectButtonModule,
-    ButtonModule,
-    InputTextModule,
-    ProgressBarModule,
-    ConfirmDialogModule
+    JoyrideModule.forRoot()
   ],
   providers: [
-      { provide: LocationStrategy, useClass: HashLocationStrategy }, BucketService, HttpService, ConfirmationService
+      { provide: LocationStrategy, useClass: HashLocationStrategy }, BucketService, HttpService
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/business/ak-sk/ak-sk.module.ts
+++ b/src/app/business/ak-sk/ak-sk.module.ts
@@ -1,9 +1,7 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { AkSkComponent } from './ak-sk.component';
 import { RouterModule } from '@angular/router';
-import { TabViewModule, ButtonModule, ConfirmDialogModule , DialogModule, DataTableModule } from '../../components/common/api';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { CommonModule } from '@angular/common';
+import {SharedModule } from '../../shared/shared.module';
 import { akSkService } from './ak-sk.service';
 
 let routers = [{
@@ -17,14 +15,7 @@ let routers = [{
   ],
   imports: [
     RouterModule.forChild(routers),
-    TabViewModule,
-    ButtonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    CommonModule,
-    ConfirmDialogModule,
-    DialogModule,
-    DataTableModule
+    SharedModule
   ],
   providers: [akSkService]
 })

--- a/src/app/business/ak-sk/ak-sk.module.ts
+++ b/src/app/business/ak-sk/ak-sk.module.ts
@@ -1,7 +1,7 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { AkSkComponent } from './ak-sk.component';
 import { RouterModule } from '@angular/router';
-import {SharedModule } from '../../shared/shared.module';
+import { SharedModule } from '../../shared/shared.module';
 import { akSkService } from './ak-sk.service';
 
 let routers = [{

--- a/src/app/business/block/block.module.ts
+++ b/src/app/business/block/block.module.ts
@@ -1,7 +1,7 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { BlockComponent } from './block.component';
+
 import { RouterModule } from '@angular/router';
-import { TabViewModule, ButtonModule } from '../../components/common/api';
+import { SharedModule } from '../../shared/shared.module';
 import { VolumeListModule } from './volumeList.module';
 import { VolumeGroupModule } from './volumeGroup.module';
 import { BucketsModule } from './buckets.module';
@@ -9,8 +9,7 @@ import { FileShareModule } from './fileShare.module';
 import { CloudBlockServiceModule } from './cloud-block-service/cloud-block-service.module';
 import { CloudFileShareModule } from './cloud-file-share/cloudFileShare.module';
 import { HostsModule } from './hosts.module';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { CommonModule } from '@angular/common';
+import { BlockComponent } from './block.component';
 
 let routers = [{
   path: '',
@@ -23,18 +22,14 @@ let routers = [{
   ],
   imports: [
     RouterModule.forChild(routers),
+    SharedModule,
     VolumeListModule,
     VolumeGroupModule,
-    TabViewModule,
-    ButtonModule,
     BucketsModule,
     FileShareModule,
     CloudBlockServiceModule,
     CloudFileShareModule,
-    HostsModule,
-    ReactiveFormsModule,
-    FormsModule,
-    CommonModule
+    HostsModule
   ],
   providers: []
 })

--- a/src/app/business/block/bucket-detail/acl/acl.module.ts
+++ b/src/app/business/block/bucket-detail/acl/acl.module.ts
@@ -1,13 +1,7 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { AclComponent } from './acl.component';
 import { RouterModule } from '@angular/router';
-import {DataTableModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputTextareaModule, 
-  DropdownModule ,ConfirmationService,ConfirmDialogModule,CalendarModule,CheckboxModule, InputSwitchModule, 
-  TableModule,TabViewModule,ButtonModule,SpinnerModule, GrowlModule } from '../../../../components/common/api';
-
-
+import { SharedModule } from 'app/shared/shared.module';
+import { AclComponent } from './acl.component';
 import { HttpService } from '../../../../shared/service/Http.service';
 import { BucketService } from '../../buckets.service';
 
@@ -17,32 +11,12 @@ import { BucketService } from '../../buckets.service';
     AclComponent
   ],
   imports: [
-    TabViewModule,
-    ButtonModule,
-    CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    ButtonModule,
-    InputTextModule,
-    InputTextareaModule,
-    DataTableModule,
-    DropdownModule,
-    DropMenuModule,
-    DialogModule,
-    FormModule,
-    ConfirmDialogModule,
     RouterModule,
-    CalendarModule,
-    CheckboxModule,
-    InputSwitchModule,
-    TableModule,
-    SpinnerModule,
-    GrowlModule
+    SharedModule
   ],
   exports: [ AclComponent ],
   providers: [
     HttpService,
-    ConfirmationService,
     BucketService
   ]
 })

--- a/src/app/business/block/bucket-detail/bucket-detail.module.ts
+++ b/src/app/business/block/bucket-detail/bucket-detail.module.ts
@@ -1,13 +1,9 @@
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { SharedModule } from 'app/shared/shared.module';
 import { BucketDetailComponent } from './bucket-detail.component';
 import { LifeCycleModule } from './lifeCycle/lifeCycle.module';
 import { AclModule } from './acl/acl.module';
-import { TabViewModule,ButtonModule, DataTableModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputSwitchModule, InputTextareaModule, 
-  ConfirmDialogModule ,ConfirmationService,CheckboxModule,DropdownModule, SplitButtonModule, GrowlModule} from './../../../components/common/api';
-  import { ProgressBarModule } from '../../../components/progressbar/progressbar';
 import { HttpService } from './../../../shared/service/Http.service';
 import { BucketService } from '../buckets.service';
 import { HttpClientModule } from '@angular/common/http';
@@ -19,26 +15,10 @@ let routers = [{
 
 @NgModule({
   imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    InputTextModule,
-    InputSwitchModule,
-    InputTextareaModule,
     RouterModule.forChild(routers),
-    TabViewModule,
-    ButtonModule,
-    DataTableModule,
-    DialogModule,
-    FormModule,
-    ConfirmDialogModule,
-    CheckboxModule,
-    DropdownModule,
+    SharedModule,
     LifeCycleModule,
     HttpClientModule,
-    SplitButtonModule,
-    GrowlModule,
-    ProgressBarModule,
     AclModule
   ],
   declarations: [
@@ -46,7 +26,6 @@ let routers = [{
   ],
   providers: [
     HttpService,
-    ConfirmationService,
     BucketService  
   ]
 })

--- a/src/app/business/block/bucket-detail/lifeCycle/lifeCycle.module.ts
+++ b/src/app/business/block/bucket-detail/lifeCycle/lifeCycle.module.ts
@@ -1,12 +1,7 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { LifeCycleComponent } from './lifeCycle.component';
 import { RouterModule } from '@angular/router';
-import {DataTableModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputTextareaModule, 
-  DropdownModule ,ConfirmationService,ConfirmDialogModule,CalendarModule,CheckboxModule, InputSwitchModule, 
-  TableModule,TabViewModule, ButtonModule,SpinnerModule, GrowlModule } from '../../../../components/common/api';
-import { SidebarModule } from '../../../../components/sidebar/sidebar';
+import { SharedModule } from 'app/shared/shared.module';
+import { LifeCycleComponent } from './lifeCycle.component';
 import { HttpService } from '../../../../shared/service/Http.service';
 import { BucketService } from '../../buckets.service';
 
@@ -15,33 +10,12 @@ import { BucketService } from '../../buckets.service';
     LifeCycleComponent
   ],
   imports: [
-    TabViewModule,
-    ButtonModule,
-    CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    ButtonModule,
-    InputTextModule,
-    InputTextareaModule,
-    DataTableModule,
-    DropdownModule,
-    DropMenuModule,
-    DialogModule,
-    FormModule,
-    ConfirmDialogModule,
     RouterModule,
-    CalendarModule,
-    CheckboxModule,
-    InputSwitchModule,
-    TableModule,
-    SpinnerModule,
-    GrowlModule,
-    SidebarModule
+    SharedModule
   ],
   exports: [ LifeCycleComponent ],
   providers: [
     HttpService,
-    ConfirmationService,
     BucketService
   ]
 })

--- a/src/app/business/block/bucket-detail/object-acl/object-acl.module.ts
+++ b/src/app/business/block/bucket-detail/object-acl/object-acl.module.ts
@@ -1,13 +1,7 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { ObjectAclComponent } from './object-acl.component';
 import { RouterModule } from '@angular/router';
-import {DataTableModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputTextareaModule, 
-  DropdownModule ,ConfirmationService,ConfirmDialogModule,CalendarModule,CheckboxModule, InputSwitchModule, 
-  TableModule,TabViewModule,ButtonModule,SpinnerModule, GrowlModule } from '../../../../components/common/api';
-
-
+import { SharedModule } from 'app/shared/shared.module';
+import { ObjectAclComponent } from './object-acl.component';
 import { HttpService } from '../../../../shared/service/Http.service';
 import { BucketService } from '../../buckets.service';
 
@@ -20,32 +14,12 @@ let routers = [{
     ObjectAclComponent
   ],
   imports: [
-    TabViewModule,
-    ButtonModule,
-    CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    ButtonModule,
     RouterModule.forChild(routers),
-    InputTextModule,
-    InputTextareaModule,
-    DataTableModule,
-    DropdownModule,
-    DropMenuModule,
-    DialogModule,
-    FormModule,
-    ConfirmDialogModule,
-    CalendarModule,
-    CheckboxModule,
-    InputSwitchModule,
-    TableModule,
-    SpinnerModule,
-    GrowlModule
+    SharedModule
   ],
   exports: [ ObjectAclComponent ],
   providers: [
     HttpService,
-    ConfirmationService,
     BucketService
   ]
 })

--- a/src/app/business/block/buckets.module.ts
+++ b/src/app/business/block/buckets.module.ts
@@ -1,11 +1,7 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
+import { SharedModule } from '../../shared/shared.module';
 import { BucketsComponent } from './buckets.component';
 import { RouterModule } from '@angular/router';
-import { TabViewModule, ButtonModule } from '../../components/common/api';
-import {DataTableModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputTextareaModule, 
-  DropdownModule ,ConfirmationService,ConfirmDialogModule,CalendarModule,CheckboxModule, InputSwitchModule, GrowlModule} from '../../components/common/api';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { CommonModule } from '@angular/common';
 import { HttpService } from './../../shared/service/Http.service';
 import { BucketService } from './buckets.service';
 import { MigrationService } from './../dataflow/migration.service';
@@ -15,30 +11,12 @@ import { MigrationService } from './../dataflow/migration.service';
     BucketsComponent
   ],
   imports: [
-    TabViewModule,
-    ButtonModule,
-    CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    ButtonModule,
-    InputTextModule,
-    InputTextareaModule,
-    DataTableModule,
-    DropdownModule,
-    DropMenuModule,
-    DialogModule,
-    FormModule,
-    ConfirmDialogModule,
     RouterModule,
-    CalendarModule,
-    CheckboxModule,
-    InputSwitchModule,
-    GrowlModule
+    SharedModule
   ],
   exports: [ BucketsComponent ],
   providers: [
     HttpService,
-    ConfirmationService,
     BucketService,
     MigrationService
   ]

--- a/src/app/business/block/cloud-block-service/cloud-block-service.module.ts
+++ b/src/app/business/block/cloud-block-service/cloud-block-service.module.ts
@@ -1,12 +1,7 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-
-import { ButtonModule, DataTableModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputTextareaModule, InputSwitchModule, DropdownModule , ConfirmationService,ConfirmDialogModule, MultiSelectModule, GrowlModule } from '../../../components/common/api';
-import { TooltipModule } from '../../../components/tooltip/tooltip';
+import { SharedModule } from 'app/shared/shared.module';
 import { HttpService } from '../../../shared/service/Http.service';
-
 import { CloudBlockServiceComponent } from './cloud-block-service.component';
 import { CloudBlockServiceService} from './cloud-block-service.service';
 
@@ -16,29 +11,13 @@ import { CloudBlockServiceService} from './cloud-block-service.service';
 @NgModule({
   declarations: [ CloudBlockServiceComponent],
   imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    ButtonModule,
-    InputTextModule,
-    InputTextareaModule,
-    InputSwitchModule,
-    DataTableModule,
-    DropdownModule,
-    DropMenuModule,
-    DialogModule,
-    FormModule,
-    ConfirmDialogModule,
     RouterModule,
-    MultiSelectModule,
-    GrowlModule,
-    TooltipModule
+    SharedModule
   ],
   exports: [ CloudBlockServiceComponent],
   providers: [
     HttpService,
-    CloudBlockServiceService,
-    ConfirmationService,
+    CloudBlockServiceService
   ]
 })
 export class CloudBlockServiceModule { }

--- a/src/app/business/block/cloud-block-service/create/cloud-volume-create.module.ts
+++ b/src/app/business/block/cloud-block-service/create/cloud-volume-create.module.ts
@@ -1,13 +1,7 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-
-import { CloudVolumeCreateComponent } from './cloud-volume-create.component';
-
 import { RouterModule } from '@angular/router';
-import {DataTableModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputTextareaModule, 
-  DropdownModule ,ConfirmationService,ConfirmDialogModule,CalendarModule,CheckboxModule, InputSwitchModule, 
-  TableModule,TabViewModule, ButtonModule, SpinnerModule, GrowlModule } from '../../../../components/common/api';
+import { SharedModule } from 'app/shared/shared.module';
+import { CloudVolumeCreateComponent } from './cloud-volume-create.component';
 import { HttpService } from '../../../../shared/service/Http.service';
 import { AvailabilityZonesService } from '../../../resource/resource.service';
 import { ProfileService } from '../../../profile/profile.service';
@@ -25,32 +19,11 @@ let routers = [{
   ],
   imports: [
     RouterModule.forChild(routers),
-    TabViewModule,
-    ButtonModule,
-    CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    ButtonModule,
-    InputTextModule,
-    InputTextareaModule,
-    DataTableModule,
-    DropdownModule,
-    DropMenuModule,
-    DialogModule,
-    FormModule,
-    ConfirmDialogModule,
-    RouterModule,
-    CalendarModule,
-    CheckboxModule,
-    InputSwitchModule,
-    TableModule,
-    SpinnerModule,
-    GrowlModule
+    SharedModule
   ],
   exports: [ CloudVolumeCreateComponent ],
   providers: [
     HttpService,
-    ConfirmationService,
     AvailabilityZonesService,
     ProfileService,
     FileShareService,

--- a/src/app/business/block/cloud-block-service/modify/cloud-volume-modify.module.ts
+++ b/src/app/business/block/cloud-block-service/modify/cloud-volume-modify.module.ts
@@ -1,13 +1,7 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-
-import { CloudVolumeModifyComponent } from './cloud-volume-modify.component';
-
 import { RouterModule } from '@angular/router';
-import {DataTableModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputTextareaModule, 
-  DropdownModule ,ConfirmationService,ConfirmDialogModule,CalendarModule,CheckboxModule, InputSwitchModule, 
-  TableModule,TabViewModule, ButtonModule, SpinnerModule, GrowlModule } from '../../../../components/common/api';
+import { SharedModule } from 'app/shared/shared.module';
+import { CloudVolumeModifyComponent } from './cloud-volume-modify.component';
 import { HttpService } from '../../../../shared/service/Http.service';
 import { AvailabilityZonesService } from '../../../resource/resource.service';
 import { ProfileService } from '../../../profile/profile.service';
@@ -25,32 +19,11 @@ let routers = [{
   ],
   imports: [
     RouterModule.forChild(routers),
-    TabViewModule,
-    ButtonModule,
-    CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    ButtonModule,
-    InputTextModule,
-    InputTextareaModule,
-    DataTableModule,
-    DropdownModule,
-    DropMenuModule,
-    DialogModule,
-    FormModule,
-    ConfirmDialogModule,
-    RouterModule,
-    CalendarModule,
-    CheckboxModule,
-    InputSwitchModule,
-    TableModule,
-    SpinnerModule,
-    GrowlModule
+    SharedModule
   ],
   exports: [ CloudVolumeModifyComponent ],
   providers: [
     HttpService,
-    ConfirmationService,
     AvailabilityZonesService,
     ProfileService,
     FileShareService,

--- a/src/app/business/block/cloud-file-share/cloudFileShare.module.ts
+++ b/src/app/business/block/cloud-file-share/cloudFileShare.module.ts
@@ -1,11 +1,7 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-
-import { ButtonModule, DataTableModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputTextareaModule, DropdownModule , ConfirmationService,ConfirmDialogModule, MultiSelectModule, GrowlModule } from '../../../components/common/api';
+import { SharedModule } from 'app/shared/shared.module';
 import { HttpService } from '../../../shared/service/Http.service';
-
 import { CloudFileShareComponent } from './cloud-file-share.component';
 import { CloudFileShareService} from './cloud-file-share.service';
 
@@ -15,27 +11,13 @@ import { CloudFileShareService} from './cloud-file-share.service';
 @NgModule({
   declarations: [ CloudFileShareComponent],
   imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    ButtonModule,
-    InputTextModule,
-    InputTextareaModule,
-    DataTableModule,
-    DropdownModule,
-    DropMenuModule,
-    DialogModule,
-    FormModule,
-    ConfirmDialogModule,
     RouterModule,
-    MultiSelectModule,
-    GrowlModule
+    SharedModule
   ],
   exports: [ CloudFileShareComponent],
   providers: [
     HttpService,
-    CloudFileShareService,
-    ConfirmationService,
+    CloudFileShareService
   ]
 })
 export class CloudFileShareModule { }

--- a/src/app/business/block/cloud-file-share/create/cloud-file-share-create.module.ts
+++ b/src/app/business/block/cloud-file-share/create/cloud-file-share-create.module.ts
@@ -1,15 +1,7 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-
-import { CloudFileShareCreateComponent } from './cloud-file-share-create.component';
-
 import { RouterModule } from '@angular/router';
-import {
-    DataTableModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputTextareaModule,
-    DropdownModule, MultiSelectModule, ConfirmationService, ConfirmDialogModule, CalendarModule, CheckboxModule, InputSwitchModule,
-    TableModule, TabViewModule, ButtonModule, SpinnerModule, GrowlModule, RadioButtonModule
-} from '../../../../components/common/api';
+import { SharedModule } from 'app/shared/shared.module';
+import { CloudFileShareCreateComponent } from './cloud-file-share-create.component';
 import { HttpService } from '../../../../shared/service/Http.service';
 import { AvailabilityZonesService } from '../../../resource/resource.service';
 import { ProfileService } from '../../../profile/profile.service';
@@ -27,34 +19,11 @@ let routers = [{
   ],
   imports: [
     RouterModule.forChild(routers),
-    TabViewModule,
-    ButtonModule,
-    CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    ButtonModule,
-    InputTextModule,
-    InputTextareaModule,
-    DataTableModule,
-    DropdownModule,
-    MultiSelectModule,
-    DropMenuModule,
-    DialogModule,
-    FormModule,
-    ConfirmDialogModule,
-    RouterModule,
-    CalendarModule,
-    CheckboxModule,
-    InputSwitchModule,
-    TableModule,
-    SpinnerModule,
-    GrowlModule,
-    RadioButtonModule
+    SharedModule
   ],
   exports: [ CloudFileShareCreateComponent ],
   providers: [
     HttpService,
-    ConfirmationService,
     AvailabilityZonesService,
     ProfileService,
     FileShareService,

--- a/src/app/business/block/cloud-file-share/modify/cloud-file-share-modify.module.ts
+++ b/src/app/business/block/cloud-file-share/modify/cloud-file-share-modify.module.ts
@@ -1,13 +1,8 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-
+import { RouterModule } from '@angular/router';
+import { SharedModule } from 'app/shared/shared.module';
 import { CloudFileShareModifyComponent } from './cloud-file-share-modify.component';
 
-import { RouterModule } from '@angular/router';
-import {DataTableModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputTextareaModule, 
-  DropdownModule ,ConfirmationService,ConfirmDialogModule,CalendarModule,CheckboxModule, InputSwitchModule, 
-  TableModule,TabViewModule, ButtonModule, SpinnerModule, GrowlModule } from '../../../../components/common/api';
 import { HttpService } from '../../../../shared/service/Http.service';
 import { ProfileService } from '../../../profile/profile.service';
 import { CloudFileShareService } from '../cloud-file-share.service';
@@ -23,32 +18,11 @@ let routers = [{
   ],
   imports: [
     RouterModule.forChild(routers),
-    TabViewModule,
-    ButtonModule,
-    CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    ButtonModule,
-    InputTextModule,
-    InputTextareaModule,
-    DataTableModule,
-    DropdownModule,
-    DropMenuModule,
-    DialogModule,
-    FormModule,
-    ConfirmDialogModule,
-    RouterModule,
-    CalendarModule,
-    CheckboxModule,
-    InputSwitchModule,
-    TableModule,
-    SpinnerModule,
-    GrowlModule
+    SharedModule
   ],
   exports: [ CloudFileShareModifyComponent ],
   providers: [
     HttpService,
-    ConfirmationService,
     ProfileService,
     CloudFileShareService
   ]

--- a/src/app/business/block/create-file-share/create-file-share.module.ts
+++ b/src/app/business/block/create-file-share/create-file-share.module.ts
@@ -1,13 +1,7 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-
-import { CreateFileShareComponent } from './create-file-share.component';
-
 import { RouterModule } from '@angular/router';
-import {DataTableModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputTextareaModule, 
-  DropdownModule ,ConfirmationService,ConfirmDialogModule,CalendarModule,CheckboxModule, InputSwitchModule, 
-  TableModule,TabViewModule, ButtonModule, SpinnerModule } from '../../../components/common/api';
+import { SharedModule } from 'app/shared/shared.module';
+import { CreateFileShareComponent } from './create-file-share.component';
 import { HttpService } from '../../../shared/service/Http.service';
 import { AvailabilityZonesService } from './../../resource/resource.service';
 import { ProfileService } from './../../profile/profile.service';
@@ -24,31 +18,11 @@ let routers = [{
   ],
   imports: [
     RouterModule.forChild(routers),
-    TabViewModule,
-    ButtonModule,
-    CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    ButtonModule,
-    InputTextModule,
-    InputTextareaModule,
-    DataTableModule,
-    DropdownModule,
-    DropMenuModule,
-    DialogModule,
-    FormModule,
-    ConfirmDialogModule,
-    RouterModule,
-    CalendarModule,
-    CheckboxModule,
-    InputSwitchModule,
-    TableModule,
-    SpinnerModule
+    SharedModule
   ],
   exports: [ CreateFileShareComponent ],
   providers: [
     HttpService,
-    ConfirmationService,
     AvailabilityZonesService,
     ProfileService,
     FileShareService

--- a/src/app/business/block/create-host/create-host.module.ts
+++ b/src/app/business/block/create-host/create-host.module.ts
@@ -1,16 +1,13 @@
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-
+import { SharedModule } from 'app/shared/shared.module';
 import { CreateHostComponent } from './create-host.component';
-
 import { HttpService } from './../../../shared/api';
 import { VolumeService,ReplicationService } from './../volume.service';
 import { ProfileService } from './../../profile/profile.service';
 import { AvailabilityZonesService } from './../../resource/resource.service';
 import { HostsService } from '../hosts.service';
-import { InputTextModule, CheckboxModule, ButtonModule, DropdownModule, MultiSelectModule, DialogModule, Message, GrowlModule, SpinnerModule, FormModule } from './../../../components/common/api';
+
 
 let routers = [{
   path: '',
@@ -20,18 +17,7 @@ let routers = [{
 @NgModule({
   imports: [
     RouterModule.forChild(routers),
-    ReactiveFormsModule,
-    FormsModule,
-    CommonModule,
-    InputTextModule,
-    CheckboxModule,
-    ButtonModule,
-    DropdownModule,
-    MultiSelectModule,
-    DialogModule,
-    GrowlModule,
-    SpinnerModule,
-    FormModule
+    SharedModule
   ],
   declarations: [
     CreateHostComponent

--- a/src/app/business/block/create-volume/create-volume.module.ts
+++ b/src/app/business/block/create-volume/create-volume.module.ts
@@ -1,16 +1,13 @@
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-
+import { SharedModule } from 'app/shared/shared.module';
 import { CreateVolumeComponent } from './create-volume.component';
 import { ReplicationGroupComponent } from './replication-group/replication-group.component';
-
 import { HttpService } from './../../../shared/api';
 import { VolumeService,ReplicationService } from './../volume.service';
 import { ProfileService } from './../../profile/profile.service';
 import { AvailabilityZonesService } from './../../resource/resource.service';
-import { InputTextModule, CheckboxModule, ButtonModule, DropdownModule, DialogModule, Message, GrowlModule, SpinnerModule, FormModule } from './../../../components/common/api';
+
 
 let routers = [{
   path: '',
@@ -20,17 +17,7 @@ let routers = [{
 @NgModule({
   imports: [
     RouterModule.forChild(routers),
-    ReactiveFormsModule,
-    FormsModule,
-    CommonModule,
-    InputTextModule,
-    CheckboxModule,
-    ButtonModule,
-    DropdownModule,
-    DialogModule,
-    GrowlModule,
-    SpinnerModule,
-    FormModule
+    SharedModule
   ],
   declarations: [
     CreateVolumeComponent,

--- a/src/app/business/block/file-share-detail/file-share-detail.module.ts
+++ b/src/app/business/block/file-share-detail/file-share-detail.module.ts
@@ -1,11 +1,7 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-
-import { FileShareDetailComponent } from './file-share-detail.component';
-
 import { RouterModule } from '@angular/router';
-import { TabViewModule, ButtonModule, DataTableModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputTextareaModule, DropdownModule , ConfirmationService,ConfirmDialogModule, MultiSelectModule, GrowlModule } from '../../../components/common/api';
+import { SharedModule } from 'app/shared/shared.module';
+import { FileShareDetailComponent } from './file-share-detail.component';
 import { HttpService } from '../../../shared/service/Http.service';
 import { FileShareService, SnapshotService ,FileShareAclService } from '../fileShare.service';
 import { ProfileService } from '../../profile/profile.service';
@@ -20,28 +16,12 @@ let routers = [{
     FileShareDetailComponent
   ],
   imports: [
-    TabViewModule,
-    ButtonModule,
-    CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    ButtonModule,
-    InputTextModule,
-    InputTextareaModule,
-    DataTableModule,
-    DropdownModule,
-    DropMenuModule,
-    DialogModule,
-    FormModule,
-    ConfirmDialogModule,
     RouterModule.forChild(routers),
-    MultiSelectModule,
-    GrowlModule
+    SharedModule
   ],
   exports: [ FileShareDetailComponent ],
   providers: [
     HttpService,
-    ConfirmationService,
     FileShareService,
     SnapshotService,
     ProfileService,

--- a/src/app/business/block/fileShare.module.ts
+++ b/src/app/business/block/fileShare.module.ts
@@ -1,34 +1,18 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { FileShareComponent } from './fileShare.component';
-import { ButtonModule, DataTableModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputTextareaModule, DropdownModule , ConfirmationService,ConfirmDialogModule, MultiSelectModule, GrowlModule, TabViewModule } from '../../components/common/api';
 
+import { FileShareComponent } from './fileShare.component';
 import { HttpService } from './../../shared/service/Http.service';
 import { FileShareService, SnapshotService, FileShareAclService } from './fileShare.service';
 import { ProfileService } from './../profile/profile.service';
 import { RouterModule } from '@angular/router';
 import { CloudFileShareModule } from './cloud-file-share/cloudFileShare.module';
+import { SharedModule } from '../..//shared/shared.module';
 
 @NgModule({
   declarations: [ FileShareComponent],
   imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    ButtonModule,
-    InputTextModule,
-    InputTextareaModule,
-    DataTableModule,
-    DropdownModule,
-    DropMenuModule,
-    DialogModule,
-    FormModule,
-    ConfirmDialogModule,
     RouterModule,
-    MultiSelectModule,
-    GrowlModule,
-    TabViewModule,
+    SharedModule,
     CloudFileShareModule
   ],
   exports: [ FileShareComponent],
@@ -37,7 +21,6 @@ import { CloudFileShareModule } from './cloud-file-share/cloudFileShare.module';
     FileShareService,
     SnapshotService,
     ProfileService,
-    ConfirmationService,
     FileShareAclService
   ]
 })

--- a/src/app/business/block/host-detail/host-detail.module.ts
+++ b/src/app/business/block/host-detail/host-detail.module.ts
@@ -1,15 +1,12 @@
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { SharedModule } from 'app/shared/shared.module';
 import { HostDetailComponent } from './host-detail.component';
-
-import { TabViewModule,ButtonModule, DataTableModule,DropdownModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputTextareaModule, ConfirmDialogModule ,ConfirmationService,CheckboxModule} from '../../../components/common/api';
 import { HttpService } from '../../../shared/service/Http.service';
 import { VolumeService} from '../volume.service';
 import { ProfileService } from '../../profile/profile.service';
 import { HostsService } from '../hosts.service';
-import {GrowlModule} from '../../../components/growl/growl';
+
 
 let routers = [{
   path: '',
@@ -18,22 +15,8 @@ let routers = [{
 
 @NgModule({
   imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    InputTextModule,
-    InputTextareaModule,
     RouterModule.forChild(routers),
-    TabViewModule,
-    ButtonModule,
-    DataTableModule,
-    DialogModule,
-    FormModule,
-    ConfirmDialogModule,
-    DropdownModule,
-    DropMenuModule,
-    CheckboxModule,
-    GrowlModule
+    SharedModule
   ],
   declarations: [
     HostDetailComponent,
@@ -42,7 +25,6 @@ let routers = [{
     HttpService,
     VolumeService,
     HostsService,
-    ConfirmationService,
     ProfileService,
   ]
 })

--- a/src/app/business/block/hosts.module.ts
+++ b/src/app/business/block/hosts.module.ts
@@ -1,25 +1,24 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { HostsComponent } from './hosts.component';
-import { ButtonModule, DataTableModule, InputTextModule, DropMenuModule, DialogModule,FormModule,MultiSelectModule, GrowlModule ,DropdownModule,InputTextareaModule} from '../../components/common/api';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { HttpService } from './../../shared/service/Http.service';
 import { VolumeService} from './volume.service';
 import { HostsService } from './hosts.service';
 import { AvailabilityZonesService } from './../resource/resource.service';
-import { ConfirmationService,ConfirmDialogModule} from '../../components/common/api';
-import { TooltipModule } from '../../components/tooltip/tooltip';
+
 import { RouterModule } from '@angular/router';
+import { SharedModule } from '../../shared/shared.module';
 
 @NgModule({
   declarations: [ HostsComponent ],
-  imports: [ CommonModule, ButtonModule, DataTableModule, InputTextModule, DropMenuModule, DialogModule,FormModule,MultiSelectModule, GrowlModule ,DropdownModule,ReactiveFormsModule,FormsModule,ConfirmDialogModule,InputTextareaModule, TooltipModule,RouterModule],
+  imports: [ 
+    RouterModule,
+    SharedModule
+  ],
   exports: [ HostsComponent ],
   providers: [
     HttpService,
     VolumeService,
     HostsService,
-    ConfirmationService,
     AvailabilityZonesService
   ]
 })

--- a/src/app/business/block/modify-host/modify-host.module.ts
+++ b/src/app/business/block/modify-host/modify-host.module.ts
@@ -1,16 +1,13 @@
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-
+import { SharedModule } from 'app/shared/shared.module';
 import { ModifyHostComponent } from './modify-host.component';
-
 import { HttpService } from './../../../shared/api';
 import { VolumeService } from './../volume.service';
 import { ProfileService } from './../../profile/profile.service';
 import { AvailabilityZonesService } from './../../resource/resource.service';
 import { HostsService } from '../hosts.service';
-import { InputTextModule, CheckboxModule, ButtonModule, DropdownModule, MultiSelectModule, DialogModule, Message, GrowlModule, SpinnerModule, FormModule } from './../../../components/common/api';
+
 
 let routers = [{
   path: '',
@@ -20,18 +17,7 @@ let routers = [{
 @NgModule({
   imports: [
     RouterModule.forChild(routers),
-    ReactiveFormsModule,
-    FormsModule,
-    CommonModule,
-    InputTextModule,
-    CheckboxModule,
-    ButtonModule,
-    DropdownModule,
-    MultiSelectModule,
-    DialogModule,
-    GrowlModule,
-    SpinnerModule,
-    FormModule
+    SharedModule
   ],
   declarations: [
     ModifyHostComponent

--- a/src/app/business/block/volume-detail/volume-detail.module.ts
+++ b/src/app/business/block/volume-detail/volume-detail.module.ts
@@ -1,11 +1,7 @@
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { SharedModule } from 'app/shared/shared.module';
 import { VolumeDetailComponent } from './volume-detail.component';
-import { DeferModule } from '../../../components/defer/defer';
-import { TabViewModule,ButtonModule, DataTableModule,DropdownModule, DropMenuModule, DialogModule, FormModule, GrowlModule, InputTextModule, InputTextareaModule, ConfirmDialogModule ,ConfirmationService,CheckboxModule} from './../../../components/common/api';
-import { TooltipModule } from '../../../components/tooltip/tooltip';
 import { HttpService } from './../../../shared/service/Http.service';
 import { VolumeService,SnapshotService ,ReplicationService} from './../volume.service';
 import { SnapshotListComponent } from './snapshot-list/snapshot-list.component';
@@ -22,24 +18,8 @@ let routers = [{
 
 @NgModule({
   imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    InputTextModule,
-    InputTextareaModule,
     RouterModule.forChild(routers),
-    TabViewModule,
-    ButtonModule,
-    DataTableModule,
-    DialogModule,
-    FormModule,
-    GrowlModule,
-    ConfirmDialogModule,
-    DropdownModule,
-    CheckboxModule,
-    TooltipModule,
-    DropMenuModule,
-    DeferModule
+    SharedModule
   ],
   declarations: [
     VolumeDetailComponent,
@@ -51,7 +31,6 @@ let routers = [{
     HttpService,
     VolumeService,
     SnapshotService,
-    ConfirmationService,
     ProfileService,
     ReplicationService,
     HostsService,

--- a/src/app/business/block/volume-group-detail/volume-group-detail.module.ts
+++ b/src/app/business/block/volume-group-detail/volume-group-detail.module.ts
@@ -1,12 +1,10 @@
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { VolumeGroupDetailComponent } from './volume-group-detail.component';
+import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { TabViewModule,ButtonModule, DataTableModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputTextareaModule, ConfirmDialogModule ,ConfirmationService} from './../../../components/common/api';
+import { SharedModule } from '../../../shared/shared.module';
 import { HttpService } from './../../../shared/service/Http.service';
 import { VolumeService,VolumeGroupService} from './../volume.service';
 import { ProfileService } from './../../profile/profile.service';
+import { VolumeGroupDetailComponent } from './volume-group-detail.component';
 
 let routers = [{
   path: '',
@@ -14,24 +12,13 @@ let routers = [{
 }]
 @NgModule({
   imports: [
-    CommonModule,
     RouterModule.forChild(routers),
-    ReactiveFormsModule,
-    FormsModule,
-    InputTextModule,
-    InputTextareaModule,
-    TabViewModule,
-    ButtonModule,
-    DataTableModule,
-    DialogModule,
-    FormModule,
-    ConfirmDialogModule
+    SharedModule
   ],
   declarations: [VolumeGroupDetailComponent],
   providers: [
     HttpService,
     VolumeService,
-    ConfirmationService,
     ProfileService,
     VolumeGroupService
   ]

--- a/src/app/business/block/volumeGroup.module.ts
+++ b/src/app/business/block/volumeGroup.module.ts
@@ -1,36 +1,22 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { VolumeGroupComponent } from './volumeGroup.component';
-import { ButtonModule, DataTableModule, InputTextModule, DialogModule,FormModule,MultiSelectModule ,DropdownModule,InputTextareaModule, GrowlModule} from '../../components/common/api';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { HttpService } from './../../shared/service/Http.service';
 import { VolumeService ,VolumeGroupService} from './volume.service';
 import { AvailabilityZonesService } from './../resource/resource.service';
-import { ConfirmationService,ConfirmDialogModule} from '../../components/common/api';
 import { RouterModule } from '@angular/router';
+import { SharedModule } from '../../shared/shared.module';
 
 @NgModule({
   declarations: [ VolumeGroupComponent ],
   imports: [ 
-    ButtonModule, 
-    DataTableModule, 
-    InputTextModule, 
-    DialogModule,
-    FormModule,
-    MultiSelectModule,
-    DropdownModule,
-    ReactiveFormsModule,
-    FormsModule,
-    ConfirmDialogModule,
-    InputTextareaModule,
-    GrowlModule,
-    RouterModule
+    RouterModule,
+    SharedModule
   ],
   exports: [ VolumeGroupComponent ],
   providers: [
     HttpService,
     VolumeService,
     VolumeGroupService,
-    ConfirmationService,
     AvailabilityZonesService
   ]
 })

--- a/src/app/business/block/volumeList.module.ts
+++ b/src/app/business/block/volumeList.module.ts
@@ -1,34 +1,19 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
 import { VolumeListComponent } from './volumeList.component';
-import { ButtonModule, DataTableModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputTextareaModule, GrowlModule, DropdownModule , ConfirmationService, ConfirmDialogModule, TabViewModule} from '../../components/common/api';
-
 import { HttpService } from './../../shared/service/Http.service';
-import {VolumeService, SnapshotService, ReplicationService} from './volume.service';
+import { VolumeService, SnapshotService, ReplicationService} from './volume.service';
 import { ProfileService } from './../profile/profile.service';
 import { AttachService } from './attach.service';
-import { RouterModule } from '@angular/router';
+
 import { CloudBlockServiceModule } from './cloud-block-service/cloud-block-service.module';
+import { SharedModule } from '../../shared/shared.module'
 
 @NgModule({
   declarations: [ VolumeListComponent ],
   imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    ButtonModule,
-    InputTextModule,
-    InputTextareaModule,
-    GrowlModule,
-    DataTableModule,
-    DropdownModule,
-    DropMenuModule,
-    DialogModule,
-    FormModule,
-    ConfirmDialogModule,
     RouterModule,
-    TabViewModule,
+    SharedModule,
     CloudBlockServiceModule
   ],
   exports: [ VolumeListComponent ],
@@ -39,7 +24,6 @@ import { CloudBlockServiceModule } from './cloud-block-service/cloud-block-servi
     ProfileService,
     AttachService,
     ReplicationService,
-    ConfirmationService
   ]
 })
 export class VolumeListModule { }

--- a/src/app/business/dataflow/dataflow.module.ts
+++ b/src/app/business/dataflow/dataflow.module.ts
@@ -1,7 +1,7 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { DataflowComponent } from './dataflow.component';
 import { RouterModule } from '@angular/router';
-import { TabViewModule, ButtonModule } from '../../components/common/api';
+import { SharedModule } from 'app/shared/shared.module';
+import { DataflowComponent } from './dataflow.component';
 import { MigrationModule } from './migration.module';
 import { ReplicationModule } from './replication.module';
 import { MigrationService } from './migration.service';
@@ -17,9 +17,8 @@ let routers = [{
   ],
   imports: [
     RouterModule.forChild(routers),
+    SharedModule,
     MigrationModule,
-    TabViewModule,
-    ButtonModule,
     ReplicationModule
   ],
   providers: [MigrationService]

--- a/src/app/business/dataflow/migration-detail/migration-detail.module.ts
+++ b/src/app/business/dataflow/migration-detail/migration-detail.module.ts
@@ -1,27 +1,15 @@
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { SharedModule } from 'app/shared/shared.module';
 import { MigrationDetailComponent } from './migration-detail.component';
-
-import { TabViewModule,ButtonModule, DataTableModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputTextareaModule, ConfirmDialogModule ,ConfirmationService} from './../../../components/common/api';
 import { HttpService } from './../../../shared/service/Http.service';
 import { MigrationService } from '../migration.service';
 
 
 @NgModule({
   imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    InputTextModule,
-    InputTextareaModule,
-    TabViewModule,
-    ButtonModule,
-    DataTableModule,
-    DialogModule,
-    FormModule,
-    ConfirmDialogModule
+    RouterModule,
+    SharedModule
   ],
   exports: [ MigrationDetailComponent ],
   declarations: [
@@ -29,7 +17,6 @@ import { MigrationService } from '../migration.service';
   ],
   providers: [
     HttpService,
-    ConfirmationService,
     MigrationService
   ]
 })

--- a/src/app/business/dataflow/migration.module.ts
+++ b/src/app/business/dataflow/migration.module.ts
@@ -1,12 +1,9 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { MigrationListComponent } from './migration.component';
-import { ButtonModule, DataTableModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputTextareaModule, DropdownModule
-   ,ConfirmationService,ConfirmDialogModule,CheckboxModule,CalendarModule, GrowlModule} from '../../components/common/api';
-
-import { HttpService } from './../../shared/service/Http.service';
 import { RouterModule } from '@angular/router';
+import { SharedModule } from 'app/shared/shared.module';
+import { MigrationListComponent } from './migration.component';
+import { HttpService } from './../../shared/service/Http.service';
+
 import { MigrationDetailModule } from './migration-detail/migration-detail.module';
 import { MigrationService } from './migration.service';
 import { BucketService } from './../block/buckets.service';
@@ -14,28 +11,13 @@ import { BucketService } from './../block/buckets.service';
 @NgModule({
   declarations: [ MigrationListComponent ],
   imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    ButtonModule,
-    InputTextModule,
-    InputTextareaModule,
-    DataTableModule,
-    DropdownModule,
-    DropMenuModule,
-    DialogModule,
-    FormModule,
-    ConfirmDialogModule,
     RouterModule,
+    SharedModule,
     MigrationDetailModule,
-    CheckboxModule,
-    CalendarModule,
-    GrowlModule
   ],
   exports: [ MigrationListComponent ],
   providers: [
     HttpService,
-    ConfirmationService,
     MigrationService,
     BucketService
   ]

--- a/src/app/business/dataflow/replication-detail/replication-detail.module.ts
+++ b/src/app/business/dataflow/replication-detail/replication-detail.module.ts
@@ -1,34 +1,21 @@
 import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
+import { SharedModule } from 'app/shared/shared.module';
 import { ReplicationDetailComponent } from './replication-detail.component';
-
-import { TabViewModule,ButtonModule, DataTableModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputTextareaModule, ConfirmDialogModule ,ConfirmationService} from './../../../components/common/api';
 import { HttpService } from './../../../shared/service/Http.service';
 
 
 @NgModule({
   imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    InputTextModule,
-    InputTextareaModule,
-    TabViewModule,
-    ButtonModule,
-    DataTableModule,
-    DialogModule,
-    FormModule,
-    ConfirmDialogModule
+    RouterModule,
+    SharedModule
   ],
   exports: [ ReplicationDetailComponent ],
   declarations: [
     ReplicationDetailComponent
   ],
   providers: [
-    HttpService,
-    ConfirmationService
+    HttpService
   ]
 })
 export class ReplicationDetailModule { }

--- a/src/app/business/dataflow/replication.module.ts
+++ b/src/app/business/dataflow/replication.module.ts
@@ -1,33 +1,20 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { ReplicationComponent } from './replication.component';
-import { ButtonModule, DataTableModule, InputTextModule, DialogModule,FormModule,MultiSelectModule ,DropdownModule,InputTextareaModule} from '../../components/common/api';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { HttpService } from './../../shared/service/Http.service';
-import { ConfirmationService,ConfirmDialogModule} from '../../components/common/api';
 import { RouterModule } from '@angular/router';
+import { SharedModule } from 'app/shared/shared.module';
+import { ReplicationComponent } from './replication.component';
+import { HttpService } from './../../shared/service/Http.service';
 import { ReplicationDetailModule } from './replication-detail/replication-detail.module';
 
 @NgModule({
   declarations: [ ReplicationComponent ],
   imports: [ 
-    ButtonModule, 
-    DataTableModule, 
-    InputTextModule,
-    DialogModule,
-    FormModule,
-    MultiSelectModule,
-    DropdownModule,
-    ReactiveFormsModule,
-    FormsModule,
-    ConfirmDialogModule,
-    InputTextareaModule,
     RouterModule,
+    SharedModule,
     ReplicationDetailModule
   ],
   exports: [ ReplicationComponent ],
   providers: [
     HttpService,
-    ConfirmationService
   ]
 })
 export class ReplicationModule { }

--- a/src/app/business/delfin/delfin.module.ts
+++ b/src/app/business/delfin/delfin.module.ts
@@ -1,7 +1,6 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-
-
+import { SharedModule } from '../../shared/shared.module';
 import { HttpService } from './../../shared/service/Http.service';
 import { DelfinComponent } from './delfin.component';
 import { DelfinService } from './delfin.service';
@@ -11,7 +10,7 @@ import { StoragesComponent } from './storages/storages.component';
 import { StorageVolumesComponent } from './volumes/volumes.component';
 import { StoragePoolsComponent } from './storage-pools/storage-pools.component';
 
-import { SharedModule } from '../../shared/shared.module';
+
 
 
 

--- a/src/app/business/delfin/delfin.module.ts
+++ b/src/app/business/delfin/delfin.module.ts
@@ -1,25 +1,19 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { CommonModule } from '@angular/common';
-import { ButtonModule, DataTableModule, PanelModule, OverlayPanelModule,  ChartModule, CardModule, TabViewModule, InputTextModule, InputSwitchModule, DropMenuModule, DialogModule,FormModule,MultiSelectModule, GrowlModule ,DropdownModule,InputTextareaModule} from '../../components/common/api';
-import { ScrollPanelModule } from '../../components/scrollpanel/scrollpanel';
-import { DataScrollerModule } from '../../components/datascroller/datascroller';
-import { TreeModule } from '../../components/tree/tree';
-import { ProgressBarModule } from '../../components/progressbar/progressbar';
-import { ContextMenuModule } from '../../components/contextmenu/contextmenu';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+
+
 import { HttpService } from './../../shared/service/Http.service';
 import { DelfinComponent } from './delfin.component';
 import { DelfinService } from './delfin.service';
 import { AvailabilityZonesService } from './../resource/resource.service';
 import { ConfirmationService,ConfirmDialogModule} from '../../components/common/api';
-import { TooltipModule } from '../../components/tooltip/tooltip';
 import { StoragesComponent } from './storages/storages.component';
-import { TableModule } from '../../components/table/table';
-import { DataViewModule } from '../../components/dataview/dataview';
 import { StorageVolumesComponent } from './volumes/volumes.component';
 import { StoragePoolsComponent } from './storage-pools/storage-pools.component';
-import { FieldsetModule } from '../../components/fieldset/fieldset'
+
+import { SharedModule } from '../../shared/shared.module';
+
+
 
 const routers: Routes = [{
     path: '',
@@ -31,35 +25,7 @@ const routers: Routes = [{
   declarations: [ DelfinComponent, StoragesComponent ],
   imports: [ 
     RouterModule.forChild(routers),
-    CommonModule, 
-    ButtonModule, 
-    TableModule,
-    ChartModule,
-    FieldsetModule,
-    DataViewModule,
-    DataTableModule,
-    PanelModule, 
-    OverlayPanelModule,
-    ScrollPanelModule,
-    DataScrollerModule,
-    TreeModule,
-    CardModule,
-    TabViewModule,
-    InputTextModule, 
-    InputSwitchModule,
-    DropMenuModule, 
-    DialogModule,
-    FormModule,
-    MultiSelectModule, 
-    GrowlModule,
-    DropdownModule,
-    ReactiveFormsModule,
-    FormsModule,
-    ConfirmDialogModule,
-    InputTextareaModule,
-    TooltipModule,
-    ProgressBarModule,
-    ContextMenuModule
+    SharedModule
     ],
   exports: [ DelfinComponent ],
   providers: [

--- a/src/app/business/delfin/modify-storage/modify-storage.module.ts
+++ b/src/app/business/delfin/modify-storage/modify-storage.module.ts
@@ -1,16 +1,11 @@
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-
+import { SharedModule } from 'app/shared/shared.module';
 import { ModifyStorageComponent } from './modify-storage.component';
-
 import { HttpService } from '../../../shared/api';
 import { ProfileService } from '../../profile/profile.service';
 import { AvailabilityZonesService } from '../../resource/resource.service';
 import { DelfinService } from '../delfin.service';
-import { InputTextModule, InputSwitchModule, CheckboxModule, ButtonModule, DropdownModule, MultiSelectModule, DialogModule, Message, GrowlModule, SpinnerModule, FormModule } from '../../../components/common/api';
-import { FieldsetModule } from '../../../components/fieldset/fieldset';
 
 let routers = [{
   path: '',
@@ -20,20 +15,7 @@ let routers = [{
 @NgModule({
   imports: [
     RouterModule.forChild(routers),
-    ReactiveFormsModule,
-    FormsModule,
-    FieldsetModule,
-    CommonModule,
-    InputTextModule,
-    InputSwitchModule,
-    CheckboxModule,
-    ButtonModule,
-    DropdownModule,
-    MultiSelectModule,
-    DialogModule,
-    GrowlModule,
-    SpinnerModule,
-    FormModule
+    SharedModule
   ],
   declarations: [ ModifyStorageComponent ],
   providers: [

--- a/src/app/business/delfin/performance-monitor/performance-monitor.module.ts
+++ b/src/app/business/delfin/performance-monitor/performance-monitor.module.ts
@@ -1,15 +1,12 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { CommonModule } from '@angular/common';
-import { ButtonModule, DataTableModule, PanelModule, OverlayPanelModule,  ChartModule, CardModule, TabViewModule, InputTextModule, InputSwitchModule, DropMenuModule, DialogModule,FormModule,MultiSelectModule, GrowlModule ,DropdownModule,InputTextareaModule} from '../../../components/common/api';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from 'app/shared/shared.module';
 import { HttpService } from '../../../shared/service/Http.service';
 import { DelfinService } from '../delfin.service';
 import { AvailabilityZonesService } from '../../resource/resource.service';
-import { ConfirmationService,ConfirmDialogModule} from '../../../components/common/api';
-import { TooltipModule } from '../../../components/tooltip/tooltip';
 import { StoragesComponent } from '../storages/storages.component';
 import { PerformanceMonitorComponent, SafePipe } from './performance-monitor.component';
+
 const routers: Routes = [{
     path: '',
     component: PerformanceMonitorComponent
@@ -20,33 +17,12 @@ const routers: Routes = [{
   declarations: [ PerformanceMonitorComponent, SafePipe],
   imports: [ 
     RouterModule.forChild(routers),
-    CommonModule, 
-    ButtonModule, 
-    ChartModule,
-    DataTableModule,
-    PanelModule, 
-    OverlayPanelModule,
-    CardModule,
-    TabViewModule,
-    InputTextModule, 
-    InputSwitchModule,
-    DropMenuModule, 
-    DialogModule,
-    FormModule,
-    MultiSelectModule, 
-    GrowlModule,
-    DropdownModule,
-    ReactiveFormsModule,
-    FormsModule,
-    ConfirmDialogModule,
-    InputTextareaModule,
-    TooltipModule,
+    SharedModule
     ],
   exports: [ PerformanceMonitorComponent ],
   providers: [
     HttpService,
     DelfinService,
-    ConfirmationService,
     AvailabilityZonesService
   ]
 })

--- a/src/app/business/delfin/register-storage/register-storage.module.ts
+++ b/src/app/business/delfin/register-storage/register-storage.module.ts
@@ -1,7 +1,6 @@
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { NgModule, APP_INITIALIZER } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { SharedModule } from '../../../shared/shared.module';
 
 import { RegisterStorageComponent } from './register-storage.component';
 
@@ -9,8 +8,6 @@ import { HttpService } from './../../../shared/api';
 import { ProfileService } from './../../profile/profile.service';
 import { AvailabilityZonesService } from './../../resource/resource.service';
 import { DelfinService } from '../delfin.service';
-import { InputTextModule, InputSwitchModule, CheckboxModule, ButtonModule, DropdownModule, MultiSelectModule, DialogModule, Message, GrowlModule, SpinnerModule, FormModule } from './../../../components/common/api';
-import { FieldsetModule } from '../../../components/fieldset/fieldset';
 
 let routers = [{
   path: '',
@@ -20,20 +17,7 @@ let routers = [{
 @NgModule({
   imports: [
     RouterModule.forChild(routers),
-    ReactiveFormsModule,
-    FormsModule,
-    FieldsetModule,
-    CommonModule,
-    InputTextModule,
-    InputSwitchModule,
-    CheckboxModule,
-    ButtonModule,
-    DropdownModule,
-    MultiSelectModule,
-    DialogModule,
-    GrowlModule,
-    SpinnerModule,
-    FormModule
+    SharedModule
   ],
   declarations: [ RegisterStorageComponent ],
   providers: [

--- a/src/app/business/delfin/storage-details/storage-details.module.ts
+++ b/src/app/business/delfin/storage-details/storage-details.module.ts
@@ -1,7 +1,6 @@
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { NgModule, APP_INITIALIZER } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { SharedModule } from '../../../shared/shared.module';
 
 import { StorageDetailsComponent, SafePipe  } from './storage-details.component';
 import { StorageVolumesComponent } from '../volumes/volumes.component';
@@ -17,9 +16,7 @@ import { HttpService } from '../../../shared/api';
 import { ProfileService } from '../../profile/profile.service';
 import { AvailabilityZonesService } from '../../resource/resource.service';
 import { DelfinService } from '../delfin.service';
-import { TabViewModule, PanelModule, DataTableModule, ChartModule, InputSwitchModule, OverlayPanelModule, CardModule, InputTextModule, CheckboxModule, ButtonModule, SplitButtonModule, DropdownModule, MultiSelectModule, DialogModule, Message, GrowlModule, SpinnerModule, FormModule } from '../../../components/common/api';
-import { TooltipModule } from '../../../components/tooltip/tooltip';
-import { ProgressBarModule } from '../../../components/progressbar/progressbar';
+
 let routers = [{
   path: '',
   component: StorageDetailsComponent
@@ -28,28 +25,7 @@ let routers = [{
 @NgModule({
   imports: [
     RouterModule.forChild(routers),
-    ReactiveFormsModule,
-    FormsModule,
-    CommonModule,
-    TabViewModule,
-    PanelModule,
-    DataTableModule,
-    ChartModule,
-    OverlayPanelModule,
-    CardModule,
-    InputTextModule,
-    InputSwitchModule,
-    CheckboxModule,
-    ButtonModule,
-    SplitButtonModule,
-    DropdownModule,
-    MultiSelectModule,
-    DialogModule,
-    GrowlModule,
-    SpinnerModule,
-    FormModule,
-    TooltipModule,
-    ProgressBarModule
+    SharedModule,
   ],
   declarations: [ 
     StorageDetailsComponent, 

--- a/src/app/business/help/help.module.ts
+++ b/src/app/business/help/help.module.ts
@@ -1,9 +1,7 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { CommonModule } from '@angular/common';
+import { SharedModule } from 'app/shared/shared.module';
 import { HelpComponent } from './help.component';
-import { TabViewModule, ButtonModule, DataTableModule, InputTextModule, CardModule, BreadcrumbModule } from './../../components/common/api';
-import {AccordionModule} from '../../components/accordion/accordion';
 import { HttpService } from './../../shared/service/Http.service';
 import { HelpHomeComponent } from './home/home-section.component';
 import { HelpResourceComponent } from './resource/resource-section.component';
@@ -38,14 +36,7 @@ let routers = [
   ],
   imports: [
     RouterModule.forChild(routers),
-    CommonModule,
-    TabViewModule,
-    ButtonModule,
-    DataTableModule,
-    InputTextModule,
-    AccordionModule,
-    CardModule,
-    BreadcrumbModule
+    SharedModule
   ],
   providers: [HttpService,]
 })

--- a/src/app/business/home/home.module.ts
+++ b/src/app/business/home/home.module.ts
@@ -1,16 +1,14 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { SharedModule } from '../../shared/shared.module';
 import { HomeComponent } from './home.component';
 import { ImgItemComponent } from './imgItem.component/imgItem.component';
 import { ProfileService } from 'app/business/profile/profile.service';
 import { HttpService } from 'app/shared/service/Http.service';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+
 import { BucketService } from '../block/buckets.service';
 import { RouterModule } from '@angular/router';
-import { ButtonModule, ChartModule,CardModule } from '../../components/common/api';
-import { DataTableModule, DropMenuModule,HomeDialogModule, DialogModule, FormModule, InputTextModule, InputTextareaModule,
-   DropdownModule ,ConfirmationService,ConfirmDialogModule, GrowlModule} from '../../components/common/api';
-   import { SidebarModule } from '../../components/sidebar/sidebar';
+
+
    import { JoyrideModule } from 'ngx-joyride';
 let routers = [{
   path: '',
@@ -23,24 +21,10 @@ let routers = [{
     ImgItemComponent,
   ],
   imports: [
-    RouterModule.forChild(routers), ButtonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    CommonModule,
-    ChartModule,
-    CardModule,
-    HomeDialogModule,
-    FormModule,
-    InputTextModule, 
-    InputTextareaModule, 
-    DropdownModule,
-    DataTableModule,
-    ConfirmDialogModule,
-    GrowlModule,
-    DialogModule,
-    SidebarModule,
+    RouterModule.forChild(routers), 
+    SharedModule,
     JoyrideModule.forChild()
   ],
-  providers: [HttpService, ProfileService,ConfirmationService,BucketService]
+  providers: [HttpService, ProfileService,BucketService]
 })
 export class HomeModule { }

--- a/src/app/business/identity/identity.module.ts
+++ b/src/app/business/identity/identity.module.ts
@@ -1,7 +1,7 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { IdentityComponent } from './identity.component';
 import { RouterModule } from '@angular/router';
-import { TabViewModule } from '../../components/common/api';
+import { SharedModule } from 'app/shared/shared.module';
+import { IdentityComponent } from './identity.component';
 import { TenantListModule } from './tenantList.module';
 import { UserListModule } from './userList.module';
 
@@ -16,9 +16,9 @@ let routers = [{
   ],
   imports: [
     RouterModule.forChild(routers),
+    SharedModule,
     TenantListModule,
-    UserListModule,
-    TabViewModule
+    UserListModule
   ],
   providers: []
 })

--- a/src/app/business/identity/tenantDetail/tenantDetail.module.ts
+++ b/src/app/business/identity/tenantDetail/tenantDetail.module.ts
@@ -1,11 +1,11 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { SharedModule } from 'app/shared/shared.module';
 import { TenantDetailComponent } from './tenantDetail.component';
-import { ButtonModule, DataTableModule, DropMenuModule, DialogModule, ConfirmDialogModule, BadgeModule, InputTextModule } from '../../../components/common/api';
+
 
 @NgModule({
   declarations: [ TenantDetailComponent ],
-  imports: [ CommonModule, ButtonModule, DataTableModule, DropMenuModule, DialogModule, ConfirmDialogModule, BadgeModule, InputTextModule ],
+  imports: [ SharedModule ],
   exports: [ TenantDetailComponent ],
   providers: []
 })

--- a/src/app/business/identity/tenantList.module.ts
+++ b/src/app/business/identity/tenantList.module.ts
@@ -1,26 +1,12 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { SharedModule } from 'app/shared/shared.module';
 import { TenantListComponent } from './tenantList.component';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { FormModule, CheckboxModule, ConfirmDialogModule, ButtonModule, MultiSelectModule, DataTableModule, DropMenuModule, DialogModule, InputTextModule, InputTextareaModule, DropdownModule } from '../../components/common/api';
 import { TenantDetailModule } from './tenantDetail/tenantDetail.module';
 
 @NgModule({
   declarations: [ TenantListComponent ],
   imports: [ 
-    CommonModule, 
-    ButtonModule, 
-    DataTableModule, 
-    DropMenuModule, 
-    DialogModule,
-    InputTextModule,
-    InputTextareaModule,
-    ReactiveFormsModule,
-    FormsModule,
-    FormModule,
-    ConfirmDialogModule,
-    MultiSelectModule,
-    CheckboxModule,
+    SharedModule,
     TenantDetailModule 
   ],
   exports: [ TenantListComponent ],

--- a/src/app/business/identity/userDetail/userDetail.module.ts
+++ b/src/app/business/identity/userDetail/userDetail.module.ts
@@ -1,11 +1,13 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { SharedModule } from 'app/shared/shared.module';
 import { userDetailComponent } from './userDetail.component';
-import { ButtonModule, DataTableModule, DropMenuModule } from '../../../components/common/api';
+
 
 @NgModule({
   declarations: [ userDetailComponent ],
-  imports: [ CommonModule, ButtonModule, DataTableModule, DropMenuModule ],
+  imports: [ 
+    SharedModule
+  ],
   exports: [ userDetailComponent ],
   providers: []
 })

--- a/src/app/business/identity/userList.module.ts
+++ b/src/app/business/identity/userList.module.ts
@@ -1,30 +1,12 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from 'app/shared/shared.module';
 import { UserListComponent } from './userList.component';
-import { BadgeModule, FormModule, ButtonModule, CheckboxModule, DataTableModule, DropMenuModule, MultiSelectModule, DialogModule, InputTextModule, InputTextareaModule, DropdownModule, PasswordModule, ConfirmDialogModule } from '../../components/common/api';
-
 import { UserDetailModule } from './userDetail/userDetail.module';
 
 @NgModule({
   declarations: [UserListComponent],
   imports: [
-    CommonModule,
-    ButtonModule,
-    BadgeModule,
-    DataTableModule,
-    DropMenuModule,
-    DialogModule,
-    ConfirmDialogModule,
-    InputTextModule,
-    InputTextareaModule,  
-    DropdownModule,
-    CheckboxModule,
-    PasswordModule,
-    FormsModule,
-    ReactiveFormsModule,
-    MultiSelectModule,
-    FormModule,
+    SharedModule,
     UserDetailModule
   ],
   exports: [UserListComponent],

--- a/src/app/business/profile/createProfile/createProfile.module.ts
+++ b/src/app/business/profile/createProfile/createProfile.module.ts
@@ -1,6 +1,5 @@
 import { Component, NgModule, APP_INITIALIZER } from '@angular/core';
 import { SharedModule } from '../../../shared/shared.module';
-
 import { CreateProfileComponent } from './createProfile.component';
 import { RouterModule } from '@angular/router';
 import { HttpService } from './../../../shared/api';

--- a/src/app/business/profile/createProfile/createProfile.module.ts
+++ b/src/app/business/profile/createProfile/createProfile.module.ts
@@ -1,9 +1,8 @@
 import { Component, NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../../../shared/shared.module';
+
 import { CreateProfileComponent } from './createProfile.component';
 import { RouterModule } from '@angular/router';
-import { InputTextModule,InputTextareaModule, CheckboxModule, FormModule, ButtonModule, DropdownModule,MultiSelectModule, RadioButtonModule, DialogModule, Message, GrowlModule, SelectButtonModule } from '../../../components/common/api';
 import { HttpService } from './../../../shared/api';
 import { ProfileService } from './../profile.service';
 import { PoolService } from './../pool.service';
@@ -19,22 +18,9 @@ let routers = [{
     CreateProfileComponent
   ],
   imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
     RouterModule.forChild(routers),
-    InputTextModule,
-    CheckboxModule,
-    ButtonModule,
-    DropdownModule,
-    RadioButtonModule,
-    DialogModule,
-    GrowlModule,
-    PoolModule,
-    SelectButtonModule,
-    FormModule,
-    InputTextareaModule,
-    MultiSelectModule
+    SharedModule,
+    PoolModule
   ],
   providers: [
     HttpService,

--- a/src/app/business/profile/modifyProfile/modifyProfile.module.ts
+++ b/src/app/business/profile/modifyProfile/modifyProfile.module.ts
@@ -1,6 +1,6 @@
 import { Component, NgModule, APP_INITIALIZER } from '@angular/core';
-import { modifyProfileComponent } from './modifyProfile.component';
 import { RouterModule } from '@angular/router';
+import { modifyProfileComponent } from './modifyProfile.component';
 import { HttpService } from './../../../shared/api';
 import { ProfileService } from './../profile.service';
 import { PoolService } from './../pool.service';

--- a/src/app/business/profile/modifyProfile/modifyProfile.module.ts
+++ b/src/app/business/profile/modifyProfile/modifyProfile.module.ts
@@ -1,14 +1,11 @@
 import { Component, NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { modifyProfileComponent } from './modifyProfile.component';
 import { RouterModule } from '@angular/router';
-import { BreadcrumbModule,ChartModule,ButtonModule } from './../../../components/common/api';
-
 import { HttpService } from './../../../shared/api';
 import { ProfileService } from './../profile.service';
 import { PoolService } from './../pool.service';
 import { PoolModule } from './../storage-pools-table/storage-pools-table.module';
-
+import { SharedModule } from '../../../shared/shared.module';
 let routers = [{
   path: '',
   component: modifyProfileComponent
@@ -19,13 +16,9 @@ let routers = [{
     modifyProfileComponent
   ],
   imports: [
-    CommonModule,
     RouterModule.forChild(routers),
-    BreadcrumbModule,
-    ChartModule,
-    ButtonModule,
+    SharedModule,
     PoolModule
-    // FormModule
   ],
   providers: [
     HttpService,

--- a/src/app/business/profile/profile.module.ts
+++ b/src/app/business/profile/profile.module.ts
@@ -1,18 +1,12 @@
-import { CommonModule } from '@angular/common';
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { ProfileComponent } from './profile.component';
 import { RouterModule } from '@angular/router';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-
 import { ProfileCardComponent } from './profileCard/profile-card.component';
-import { ButtonModule,CardModule,ChartModule,MessageModule,OverlayPanelModule,DialogModule ,ConfirmationService,ConfirmDialogModule, FormModule, DropMenuModule, GrowlModule} from '../../components/common/api';
-import { TooltipModule } from '../../components/tooltip/tooltip';
-import { ClipboardModule } from 'ngx-clipboard';
+import { ProfileComponent } from './profile.component';
 import { ProfileService } from './profile.service';
 import { PoolService } from './pool.service';
 import { HttpService } from '../../shared/api';
 import { SuspensionFrameComponent } from './profileCard/suspension-frame/suspension-frame.component';
-
+import { SharedModule } from '../../shared/shared.module';
 let routers = [{
   path: '',
   component: ProfileComponent
@@ -26,26 +20,11 @@ let routers = [{
   ],
   imports: [
     RouterModule.forChild(routers),
-    ReactiveFormsModule,
-    FormsModule,
-    ButtonModule,
-    CommonModule,
-    CardModule,
-    ChartModule,
-    MessageModule,
-    OverlayPanelModule,
-    DialogModule,
-    ConfirmDialogModule,
-    FormModule,
-    DropMenuModule,
-    GrowlModule,
-    TooltipModule,
-    ClipboardModule
+    SharedModule
   ],
   providers: [
     HttpService,
     ProfileService,
-    ConfirmationService,
     PoolService
   ]
 })

--- a/src/app/business/profile/storage-pools-table/storage-pools-table.module.ts
+++ b/src/app/business/profile/storage-pools-table/storage-pools-table.module.ts
@@ -1,7 +1,6 @@
-import { CommonModule } from '@angular/common';
 import { NgModule, APP_INITIALIZER } from '@angular/core';
+import { SharedModule } from 'app/shared/shared.module';
 
-import { TableModule } from './../../../components/common/api';
 import { HttpService } from './../../../shared/api';
 import { PoolService } from './../pool.service';
 
@@ -12,8 +11,7 @@ import { StoragePoolsTableComponent } from './storage-pools-table.component';
     StoragePoolsTableComponent
   ],
   imports: [
-    CommonModule,
-    TableModule
+    SharedModule
   ],
   providers: [
     HttpService,

--- a/src/app/business/resource/resource.module.ts
+++ b/src/app/business/resource/resource.module.ts
@@ -1,8 +1,7 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { ResourceComponent } from './resource.component';
 import { RouterModule } from '@angular/router';
-import { TabViewModule, ButtonModule, DataTableModule, InputTextModule } from './../../components/common/api';
+import { SharedModule } from 'app/shared/shared.module';
 import { HttpService } from './../../shared/service/Http.service';
 import { AvailabilityZonesService } from './resource.service';
 
@@ -17,11 +16,7 @@ let routers = [{
   ],
   imports: [
     RouterModule.forChild(routers),
-    CommonModule,
-    TabViewModule,
-    ButtonModule,
-    DataTableModule,
-    InputTextModule,
+    SharedModule
   ],
   providers: [HttpService,AvailabilityZonesService]
 })

--- a/src/app/business/services/services.module.ts
+++ b/src/app/business/services/services.module.ts
@@ -1,17 +1,7 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { CommonModule } from "@angular/common";
+import { SharedModule } from 'app/shared/shared.module';
 import { ServicesComponent } from './services.component';
 import { ServicesRoutingModule } from './services-routing.module';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { TabViewModule, ButtonModule, SplitButtonModule, 
-  ConfirmDialogModule , DialogModule, PanelModule, MessageModule,
-  DataTableModule, OverlayPanelModule, InputTextModule,
-  InputTextareaModule, CheckboxModule, FormModule,
-  DropdownModule, RadioButtonModule,
-  SelectButtonModule, ConfirmationService, SpinnerModule} from '../../components/common/api';
-import {CardModule} from '../../components/card/card';
-import {GrowlModule} from '../../components/growl/growl';
-import {TooltipModule} from '../../components/tooltip/tooltip';
 import { RouterModule } from '@angular/router';
 import { InstanceListComponent } from './instance-list/instance-list.component';
 import { ServicesListComponent } from './services-list/services-list.component';
@@ -32,32 +22,12 @@ import { DynamicFormComponent } from './dynamic-form/dynamic-form.component';
     DynamicFormComponent,
     CreateClusterComponent
   ],
-  imports: [CommonModule,
-    ReactiveFormsModule,
-    FormsModule,
-    InputTextModule,
-    InputTextareaModule,
-    CheckboxModule,
-    FormModule,
-    DropdownModule,
-    RadioButtonModule,
-    SelectButtonModule,
+  imports: [
+    SharedModule,
     ServicesRoutingModule,
-    TabViewModule,
-    ButtonModule,
-    SplitButtonModule,
-    ConfirmDialogModule,
-    DialogModule,
-    CardModule,
-    GrowlModule,
-    PanelModule,
-    MessageModule,
-    TooltipModule,
-    DataTableModule,
-    OverlayPanelModule,
     HttpClientModule,
-    SpinnerModule],
+  ],
   exports: [ServicesRoutingModule],
-  providers: [WorkflowService, ProfileService, HostsService, ConfirmationService]
+  providers: [WorkflowService, ProfileService, HostsService]
 })
 export class ServicesModule { }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,9 +1,50 @@
 import { NgModule, ModuleWithProviders, APP_INITIALIZER, Injector } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
 import { ExceptionService, MsgBoxService, I18NService, HttpService, ParamStorService } from './api';
 import { SharedConfig } from './shared.config';
-import { I18N, MsgBoxModule } from '../components/common/api';
+import { 
+    ButtonModule, 
+    DataTableModule, 
+    PanelModule, 
+    OverlayPanelModule,  
+    ChartModule, 
+    CardModule, 
+    TabViewModule, 
+    InputTextModule, 
+    InputSwitchModule, 
+    DropMenuModule, 
+    DialogModule, 
+    FormModule,
+    MultiSelectModule, 
+    GrowlModule ,
+    DropdownModule,
+    InputTextareaModule, 
+    I18N, 
+    MsgBoxModule,
+    ConfirmDialogModule,
+    CheckboxModule, 
+    SplitButtonModule, 
+    SpinnerModule,
+    MessageModule,
+    ConfirmationService,
+    RadioButtonModule,
+    SelectButtonModule,
+    BreadcrumbModule,
+    HomeDialogModule,
+} from '../components/common/api';
+import { TooltipModule } from '../components/tooltip/tooltip';
+import { SidebarModule } from '../components/sidebar/sidebar';
+import { ScrollPanelModule } from '../components/scrollpanel/scrollpanel';
+import { DataScrollerModule } from '../components/datascroller/datascroller';
+import { TreeModule } from '../components/tree/tree';
+import { ProgressBarModule } from '../components/progressbar/progressbar';
+import { ContextMenuModule } from '../components/contextmenu/contextmenu';
+import { TableModule } from '../components/table/table';
+import { DataViewModule } from '../components/dataview/dataview';
+import { FieldsetModule } from '../components/fieldset/fieldset'
 import { XHRBackend, RequestOptions, Http } from '@angular/http';
+import { ClipboardModule } from 'ngx-clipboard';
 
 export function httpFactory(backend: XHRBackend, options: RequestOptions, injector: Injector){
     options.headers.set("contentType", "application/json; charset=UTF-8");
@@ -17,7 +58,48 @@ export function httpFactory(backend: XHRBackend, options: RequestOptions, inject
 
 @NgModule({
     imports:[MsgBoxModule],
-    exports:[FormsModule, MsgBoxModule]
+    exports:[
+        CommonModule,
+        FormsModule, 
+        ReactiveFormsModule,
+        MsgBoxModule,
+        ButtonModule, 
+        DataTableModule, 
+        PanelModule, 
+        OverlayPanelModule,  
+        ChartModule, 
+        CardModule, 
+        TabViewModule, 
+        InputTextModule, 
+        InputSwitchModule, 
+        DropMenuModule, 
+        DialogModule, 
+        FormModule,
+        MultiSelectModule, 
+        GrowlModule ,
+        DropdownModule,
+        InputTextareaModule,
+        TooltipModule,
+        TableModule,
+        FieldsetModule,
+        DataViewModule,
+        ScrollPanelModule,
+        DataScrollerModule,
+        TreeModule,
+        ProgressBarModule,
+        ContextMenuModule,
+        ConfirmDialogModule,
+        CheckboxModule, 
+        SplitButtonModule, 
+        SpinnerModule,
+        MessageModule,
+        ClipboardModule,
+        RadioButtonModule,
+        SelectButtonModule,
+        BreadcrumbModule,
+        HomeDialogModule,
+        SidebarModule,
+    ]
 })
 
 export class SharedModule {
@@ -28,6 +110,7 @@ export class SharedModule {
                 MsgBoxService,
                 I18NService,
                 ParamStorService,
+                ConfirmationService,
                 ExceptionService,
                 {
                     provide: Http,

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -32,7 +32,14 @@ import {
     SelectButtonModule,
     BreadcrumbModule,
     HomeDialogModule,
+    CalendarModule,
+    BadgeModule,
+    PasswordModule
 } from '../components/common/api';
+import { AccordionModule } from '../components/accordion/accordion';
+import { DeferModule } from '../components/defer/defer';
+import { InplaceModule } from '../components/inplace/inplace';
+import { ChipsModule } from '../components/chips/chips';
 import { TooltipModule } from '../components/tooltip/tooltip';
 import { SidebarModule } from '../components/sidebar/sidebar';
 import { ScrollPanelModule } from '../components/scrollpanel/scrollpanel';
@@ -99,6 +106,13 @@ export function httpFactory(backend: XHRBackend, options: RequestOptions, inject
         BreadcrumbModule,
         HomeDialogModule,
         SidebarModule,
+        CalendarModule,
+        InplaceModule,
+        ChipsModule,
+        DeferModule,
+        AccordionModule,
+        BadgeModule,
+        PasswordModule
     ]
 })
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR cleans up the code and removes the duplicate module injections for PrimeNG Components and other common modules like Angular Common, Forms and ReactiveForms.
These common modules are now injected via the SharedModule. This makes it easier for upgrading the underlying framework and reduces code clutter.

**Which issue(s) this PR fixes**:
Fixes #597 

**Test Report Added?**:
/kind TESTED

**Test Report**:

**Special notes for your reviewer**:
