### PR TITLE
[Service Plan UI] Fixed the issue of service plan enabled in dashboard even when the installer flag is set to false.

### DIFF
--- a/src/app/shared/shared.config.ts
+++ b/src/app/shared/shared.config.ts
@@ -26,7 +26,11 @@ export class SharedConfig{
                 Consts.SODA_PROMETHEUS_PORT = r.json().prometheusPort;
                 Consts.SODA_ALERTMANAGER_PORT = r.json().alertmanagerPort;
                 Consts.SODA_GRAFANA_PORT = r.json().grafanaPort;
-                Consts.STORAGE_SERVICE_PLAN_ENABLED = r.json().servicePlansEnabled;
+                if(r.json().servicePlansEnabled == true || r.json().servicePlansEnabled.toLowerCase() == "true"){
+                    Consts.STORAGE_SERVICE_PLAN_ENABLED = true;        
+                } else if(!r.json().servicePlansEnabled || r.json().servicePlansEnabled == false || r.json().servicePlansEnabled.toLowerCase() == "false" || undefined == r.json().servicePlansEnabled || r.json().servicePlansEnabled == ""){
+                    Consts.STORAGE_SERVICE_PLAN_ENABLED = false;
+                }
                 resolve();
             })
         })


### PR DESCRIPTION

**What type of PR is this?**
 /kind bug fix

**What this PR does / why we need it**:
This PR fixes the issue of Storage Service Plans UI being enabled in the dashboard even when the user has installed SODA with the `enable_storage_service_plan = false`.
Due to the way in which yaml parsing is done for variables, the statement `enable_storage_service_plan = false` is set to `False` in the environment variable which in turn was written to the `runtime.json` file in the `entrypoint.sh` script. During this step the value was written as a string instead of a boolean and this broke the UI checks which were expecting a boolean.
This has now been handled by checking the value of the `"servicePlansEnabled" ` key in the runtime.json file and setting the flag  `Consts.STORAGE_SERVICE_PLAN_ENABLED` with the appropriate value. 
This ensures that the value of the flag is set to a Javascript boolean, irrespective of the type of value sent.

**Which issue(s) this PR fixes**:
Fixes #615 

**Test Report Added?**:
 /kind TESTED


**Test Report**:
This is tested on the local dev environment and with a local image.

**Special notes for your reviewer**:
