### PR TITLE
Removed the Ubuntu16 run from the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-latest]
+        os: [ubuntu-18.04, ubuntu-latest]
         node-version: [8.x]
         
     # Steps represent a sequence of tasks that will be executed as part of the job


### PR DESCRIPTION

**What type of PR is this?**
/kind enhancement

**What this PR does / why we need it**:
Due to [deprecation of support](https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/) removed the Ubuntu 16.04 run from the GitHub Actions.

**Which issue(s) this PR fixes**:
Fixes #

**Test Report Added?**:
> /kind NOT-TESTED

**Test Report**:

**Special notes for your reviewer**:
