### PR TITLE
Added fix for foldername prefix with null on fresh SODA installation.

### DIFF
--- a/src/app/business/block/bucket-detail/bucket-detail.component.ts
+++ b/src/app/business/block/bucket-detail/bucket-detail.component.ts
@@ -298,7 +298,7 @@ export class BucketDetailComponent implements OnInit {
   //Click on folder
   folderLink(file){
     let folderKey = file.Key;
-    if(this.folderId == ""){
+    if(this.folderId !== null && this.folderId !== ""){
       this.folderId = folderKey;
     }else{
       this.folderId = this.folderId + folderKey;


### PR DESCRIPTION
**What type of PR is this?**
/kind bug fix
**What this PR does / why we need it**:
This PR fixes the issue of null being prefixed to the folder name when a new folder is created for the first time on a fresh SODA installation.
This same issue was encountered in the upload of an object and the fix was applied n the object upload.
Same fix is applied here.

**Which issue(s) this PR fixes**:
Fixes #500 

**Test Report Added?**:
/kind TESTED


**Test Report**:

**Special notes for your reviewer**:
