### PR TITLE
Add fake storage for Delfin tests

### DIFF
--- a/src/app/shared/utils/consts.ts
+++ b/src/app/shared/utils/consts.ts
@@ -182,6 +182,10 @@ export const Consts = {
     STORAGES: {
         vendors: [
             {
+                label: "Test Storage",
+                value: 'fake_storage'
+            },
+            {
                 label: "Dell EMC",
                 value: 'dellemc'
             },
@@ -215,17 +219,30 @@ export const Consts = {
             }
         ],
         resources:{
-            volumes : ['vmax', 'unity', 'vnx_block', 'vplex', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'cmode', 'eternus', 'flasharray', 'msa', 'ds8k'],
-            pools : ['vmax', 'unity', 'vnx_block', 'vplex', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'cmode', 'eternus', 'msa', 'hnas', 'ds8k'],
-            controllers : ['oceanstor', 'unity', 'vnx_block', 'vplex', '3par', 'vsp', 'storwize_svc', 'cmode', 'vmax', 'eternus', 'flasharray', 'msa', 'hnas', 'ds8k'],
-            ports : ['oceanstor', 'unity', 'vnx_block', 'vplex', '3par', 'vsp', 'storwize_svc', 'cmode', 'vmax', 'eternus', 'flasharray', 'msa', 'hnas', 'ds8k'],
-            disks : ['oceanstor', 'unity', 'vnx_block', '3par', 'vsp', 'storwize_svc', 'cmode', 'vmax', 'eternus', 'flasharray', 'msa', 'hnas'],
-            qtrees : ['oceanstor', 'unity', 'cmode', 'hnas'],
-            filesystems : ['oceanstor', 'unity', 'cmode', 'hnas'],
-            shares: ['oceanstor', 'unity', 'cmode', 'hnas'],
-            quotas: ['oceanstor', 'unity', 'cmode', 'hnas']
+            volumes : ['fake_driver', 'vmax', 'unity', 'vnx_block', 'vplex', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'cmode', 'eternus', 'flasharray', 'msa', 'ds8k'],
+            pools : ['fake_driver', 'vmax', 'unity', 'vnx_block', 'vplex', 'oceanstor', '3par', 'vsp', 'storwize_svc', 'cmode', 'eternus', 'msa', 'hnas', 'ds8k'],
+            controllers : ['fake_driver', 'oceanstor', 'unity', 'vnx_block', 'vplex', '3par', 'vsp', 'storwize_svc', 'cmode', 'vmax', 'eternus', 'flasharray', 'msa', 'hnas', 'ds8k'],
+            ports : ['fake_driver', 'oceanstor', 'unity', 'vnx_block', 'vplex', '3par', 'vsp', 'storwize_svc', 'cmode', 'vmax', 'eternus', 'flasharray', 'msa', 'hnas', 'ds8k'],
+            disks : ['fake_driver', 'oceanstor', 'unity', 'vnx_block', '3par', 'vsp', 'storwize_svc', 'cmode', 'vmax', 'eternus', 'flasharray', 'msa', 'hnas'],
+            qtrees : ['fake_driver', 'oceanstor', 'unity', 'cmode', 'hnas'],
+            filesystems : ['fake_driver', 'oceanstor', 'unity', 'cmode', 'hnas'],
+            shares: ['fake_driver', 'oceanstor', 'unity', 'cmode', 'hnas'],
+            quotas: ['fake_driver', 'oceanstor', 'unity', 'cmode', 'hnas']
         },
         models: {
+            'fake_storage' : [
+                {
+                    label: "Test Storage",
+                    value: {
+                        name: 'fake_driver',
+                        rest: true,
+                        ssh: true,
+                        cli: true,
+                        smis: true,
+                        extra: true
+                    }
+                }
+            ],
             'dellemc' : [
                 {
                     label: "VMAX",


### PR DESCRIPTION
Add support for Delfin's test storage, "fake_storage"

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

> /kind enhancement

**What this PR does / why we need it**:
Currently if anybody wants to try out Delfin and do not have a storage array,  will not be able to do so.
This PR will add fake_storage to dashboard, that is used internally by Delfin to test all API's

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Test Report Added?**:
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind TESTED
> /kind NOT-TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
